### PR TITLE
MicroPlumberd.Services.Identity: declarative identity seeding on readiness, never fatal (epic-083 feature-001, patch)

### DIFF
--- a/src/MicroPluberd.Examples.Blazor.Identity2/Program.cs
+++ b/src/MicroPluberd.Examples.Blazor.Identity2/Program.cs
@@ -69,14 +69,27 @@ public class Program
             return null;
         });
 
-        // Seed admin user if no users exist
-        builder.Services.AddIdentityInitializer(opts =>
-        {
-            opts.AdminEmail = builder.Configuration["Identity:AdminEmail"] ?? "admin@localhost";
-            opts.AdminUserName = builder.Configuration["Identity:AdminUserName"] ?? "admin";
-            opts.AdminPassword = builder.Configuration["Identity:AdminPassword"] ?? "Admin123!";
-            opts.ProjectionWaitTime = TimeSpan.FromSeconds(5);
-        });
+        // Declare the identity state that must exist. The seed runs once the identity read models are live,
+        // converges the store to this declaration, and never stops the host.
+        builder.Services.AddIdentitySeed(seed => seed
+            .Role("Administrator")
+            .User(builder.Configuration["Identity:AdminEmail"] ?? "admin@localhost", u => u
+                .WithUserName(builder.Configuration["Identity:AdminUserName"] ?? "admin")
+                .WithPassword(builder.Configuration["Identity:AdminPassword"] ?? "Admin123!")
+                .InRoles("Administrator"))
+            .WaitUpTo(TimeSpan.FromSeconds(30)));
+
+        // Opt-in readiness entry: "identity" is Unhealthy (naming the step or the last error) until the seed
+        // converged, Healthy afterwards.
+        builder.Services.AddHealthChecks()
+            .AddPlumberdHealthChecks()
+            .AddIdentitySeedHealthCheck();
+
+        // A stated choice, never the silent default (requirement R8). The .NET default is StopHost: one throwing
+        // background service takes the whole host down, which in a container is a restart loop. The identity seed
+        // never throws out of ExecuteAsync, but other hosted services might, so the host says what it wants.
+        builder.Services.Configure<HostOptions>(o =>
+            o.BackgroundServiceExceptionBehavior = BackgroundServiceExceptionBehavior.Ignore);
 
         builder.Services.AddSingleton<IEmailSender<User>, IdentityNoOpEmailSender>();
 
@@ -97,6 +110,8 @@ public class Program
         app.MapStaticAssets();
         app.MapRazorComponents<App>()
             .AddInteractiveServerRenderMode();
+
+        app.MapHealthChecks("/health");
 
         // Add additional endpoints required by the Identity /Account Razor components.
         app.MapAdditionalIdentityEndpoints();

--- a/src/MicroPlumberd.Service.Identity/ContainerExtensions.cs
+++ b/src/MicroPlumberd.Service.Identity/ContainerExtensions.cs
@@ -131,7 +131,11 @@ namespace MicroPlumberd.Services.Identity
                 services.TryAddSingleton(Microsoft.Extensions.Options.Options.Create(new IdentityInitializerOptions()));
             }
 
-            services.AddSingleton(IdentitySeedDeclaration.FromOptions());
+            // The options-backed declaration contributes the whole legacy seed, so it must be registered once
+            // however many times AddIdentityInitializer is called - otherwise the plan doubles.
+            if (!services.Any(d => d.ImplementationInstance is IdentitySeedDeclaration { IsFromOptions: true }))
+                services.AddSingleton(IdentitySeedDeclaration.FromOptions());
+
             RegisterSeedRunner(services);
             return services;
         }
@@ -142,22 +146,13 @@ namespace MicroPlumberd.Services.Identity
         /// <c>AddIdentitySeedHealthCheck</c> are called.
         /// </summary>
         /// <remarks>
-        /// This mirrors <c>MicroPlumberd.Services.ContainerExtensions.AddBackgroundServiceIfMissing</c>, but
-        /// dedupes on an explicit marker: that helper's guard matches on
-        /// <c>ServiceDescriptor.ImplementationType</c>, which is null for the factory registration it itself adds,
-        /// so it does not actually dedupe.
+        /// <c>AddHostedService(sp =&gt; ...)</c> registers through <c>TryAddEnumerable</c> with the descriptor's
+        /// implementation type taken from the factory's generic argument, so repeat calls are already deduped.
         /// </remarks>
         internal static void RegisterSeedRunner(IServiceCollection services)
         {
             services.TryAddSingleton<IdentitySeedPlan>();
-            services.TryAddSingleton(sp => new IdentityInitializerService(
-                sp,
-                sp.GetRequiredService<IdentitySeedPlan>(),
-                sp.GetRequiredService<ILogger<IdentityInitializerService>>()));
-
-            if (services.Any(d => d.ServiceType == typeof(IdentitySeedHostedMarker))) return;
-
-            services.AddSingleton<IdentitySeedHostedMarker>();
+            services.TryAddSingleton<IdentityInitializerService>();
             services.AddHostedService(sp => sp.GetRequiredService<IdentityInitializerService>());
         }
 

--- a/src/MicroPlumberd.Service.Identity/ContainerExtensions.cs
+++ b/src/MicroPlumberd.Service.Identity/ContainerExtensions.cs
@@ -9,6 +9,7 @@ using MicroPlumberd.Services;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
 using static MicroPlumberd.Services.Identity.Aggregates.RoleAggregate;
 
 namespace MicroPlumberd.Services.Identity
@@ -70,8 +71,48 @@ namespace MicroPlumberd.Services.Identity
         }
 
         /// <summary>
+        /// Declares, fluently, the identity state that must exist after start-up: roles, users and optional
+        /// consumer steps. The seed runs on readiness (the identity read models report
+        /// <see cref="ICaughtUpHandler.CaughtUp"/>), converges the store to the declaration, and never stops the
+        /// host — see <see cref="IdentityInitializerService"/>.
+        /// </summary>
+        /// <remarks>
+        /// May be called more than once: declarations accumulate in registration order and the hosted runner is
+        /// registered exactly once. The last <see cref="IdentitySeedBuilder.WaitUpTo"/> wins.
+        /// </remarks>
+        /// <param name="services">The service collection to add services to.</param>
+        /// <param name="configure">The fluent declaration.</param>
+        /// <returns>The service collection for method chaining.</returns>
+        /// <example>
+        /// <code>
+        /// services.AddIdentitySeed(seed => seed
+        ///     .Role("Administrator")
+        ///     .User("admin@localhost", u => u.WithUserName("admin").WithPassword(pwd).InRoles("Administrator"))
+        ///     .WaitUpTo(TimeSpan.FromSeconds(30)));
+        /// </code>
+        /// </example>
+        public static IServiceCollection AddIdentitySeed(
+            this IServiceCollection services,
+            Action<IdentitySeedBuilder> configure)
+        {
+            ArgumentNullException.ThrowIfNull(services);
+            ArgumentNullException.ThrowIfNull(configure);
+
+            services.AddSingleton(new IdentitySeedDeclaration(configure));
+            RegisterSeedRunner(services);
+            return services;
+        }
+
+        /// <summary>
         /// Adds the identity initializer service that seeds an admin user on first startup.
         /// </summary>
+        /// <remarks>
+        /// Backward-compatible adapter over <see cref="AddIdentitySeed"/> (requirement R7): the options are read
+        /// at run time and contribute <c>Role(AdminRoleName)</c>,
+        /// <c>User(AdminEmail, WithUserName(AdminUserName), WithPassword(AdminPassword), InRoles(AdminRoleName))</c>
+        /// and <c>WaitUpTo(ProjectionWaitTime)</c>. <see cref="IdentityInitializerOptions.SeedAdminUser"/> set to
+        /// false contributes nothing, so the seed is ready immediately.
+        /// </remarks>
         /// <param name="services">The service collection to add services to.</param>
         /// <param name="configure">Optional action to configure the identity initializer options.</param>
         /// <returns>The service collection for method chaining.</returns>
@@ -79,6 +120,8 @@ namespace MicroPlumberd.Services.Identity
             this IServiceCollection services,
             Action<IdentityInitializerOptions>? configure = null)
         {
+            ArgumentNullException.ThrowIfNull(services);
+
             if (configure != null)
             {
                 services.Configure(configure);
@@ -88,8 +131,34 @@ namespace MicroPlumberd.Services.Identity
                 services.TryAddSingleton(Microsoft.Extensions.Options.Options.Create(new IdentityInitializerOptions()));
             }
 
-            services.AddHostedService<IdentityInitializerService>();
+            services.AddSingleton(IdentitySeedDeclaration.FromOptions());
+            RegisterSeedRunner(services);
             return services;
+        }
+
+        /// <summary>
+        /// Registers the seed plan and the hosted runner exactly once, however many times
+        /// <see cref="AddIdentitySeed"/> / <see cref="AddIdentityInitializer"/> /
+        /// <c>AddIdentitySeedHealthCheck</c> are called.
+        /// </summary>
+        /// <remarks>
+        /// This mirrors <c>MicroPlumberd.Services.ContainerExtensions.AddBackgroundServiceIfMissing</c>, but
+        /// dedupes on an explicit marker: that helper's guard matches on
+        /// <c>ServiceDescriptor.ImplementationType</c>, which is null for the factory registration it itself adds,
+        /// so it does not actually dedupe.
+        /// </remarks>
+        internal static void RegisterSeedRunner(IServiceCollection services)
+        {
+            services.TryAddSingleton<IdentitySeedPlan>();
+            services.TryAddSingleton(sp => new IdentityInitializerService(
+                sp,
+                sp.GetRequiredService<IdentitySeedPlan>(),
+                sp.GetRequiredService<ILogger<IdentityInitializerService>>()));
+
+            if (services.Any(d => d.ServiceType == typeof(IdentitySeedHostedMarker))) return;
+
+            services.AddSingleton<IdentitySeedHostedMarker>();
+            services.AddHostedService(sp => sp.GetRequiredService<IdentityInitializerService>());
         }
 
         /// <summary>

--- a/src/MicroPlumberd.Service.Identity/ContainerExtensions.cs
+++ b/src/MicroPlumberd.Service.Identity/ContainerExtensions.cs
@@ -81,7 +81,10 @@ namespace MicroPlumberd.Services.Identity
         /// registered exactly once. The last <see cref="IdentitySeedBuilder.WaitUpTo"/> wins.
         /// </remarks>
         /// <param name="services">The service collection to add services to.</param>
-        /// <param name="configure">The fluent declaration.</param>
+        /// <param name="configure">
+        /// The fluent declaration. May be invoked more than once (the plan is rebuilt on each retry until it
+        /// succeeds); keep it free of side effects.
+        /// </param>
         /// <returns>The service collection for method chaining.</returns>
         /// <example>
         /// <code>

--- a/src/MicroPlumberd.Service.Identity/IdentityInitializerOptions.cs
+++ b/src/MicroPlumberd.Service.Identity/IdentityInitializerOptions.cs
@@ -32,8 +32,11 @@ public class IdentityInitializerOptions
     public string AdminRoleName { get; set; } = "Admin";
 
     /// <summary>
-    /// Time to wait for projections to catch up before checking for users.
-    /// This delay ensures read models are populated after EventStore starts.
+    /// Per-attempt readiness bound; maps onto <see cref="IdentitySeedBuilder.WaitUpTo"/>.
+    /// It is not a delay: the seed starts as soon as the identity read models report
+    /// <see cref="ICaughtUpHandler.CaughtUp"/>. This value bounds one attempt — how long it may wait for that
+    /// catch-up, and how long each write may take to become visible in the read model the next step reads.
+    /// Expiry fails the attempt (logged at Error, retried with backoff), never the host.
     /// Default: 30 seconds
     /// </summary>
     public TimeSpan ProjectionWaitTime { get; set; } = TimeSpan.FromSeconds(30);

--- a/src/MicroPlumberd.Service.Identity/IdentityInitializerService.cs
+++ b/src/MicroPlumberd.Service.Identity/IdentityInitializerService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using MicroPlumberd.Services.Identity.ReadModels;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.DependencyInjection;
@@ -19,13 +20,21 @@ namespace MicroPlumberd.Services.Identity;
 /// and its progress is <b>observable</b> through <see cref="State"/> and the opt-in <c>identity</c> health check.
 /// </para>
 /// </summary>
-public sealed class IdentityInitializerService : BackgroundService
+public class IdentityInitializerService : BackgroundService
 {
     private readonly IServiceProvider _sp;
     private readonly IdentitySeedPlan _plan;
     private readonly ILogger<IdentityInitializerService> _logger;
     private readonly TimeProvider _time;
     private readonly TaskCompletionSource _completed = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    /// <summary>
+    /// Writes that already succeeded, keyed by kind + normalized key, carried across attempts (design.md §4.3).
+    /// A retry after a timed-out visibility wait must not create a second role, user or membership: the stores
+    /// dedupe only against the (still unfolded) read models.
+    /// </summary>
+    private readonly ConcurrentDictionary<string, string> _written = new();
+
     private volatile IdentitySeedState _state = new(false, "not started", 0);
 
     /// <summary>
@@ -33,13 +42,13 @@ public sealed class IdentityInitializerService : BackgroundService
     /// the backoff; otherwise <see cref="TimeProvider.System"/> is used.
     /// </summary>
     /// <param name="sp">Root service provider; a scope is created per attempt.</param>
-    /// <param name="plan">The accumulated seed declarations.</param>
     /// <param name="logger">Logger.</param>
-    internal IdentityInitializerService(IServiceProvider sp, IdentitySeedPlan plan, ILogger<IdentityInitializerService> logger)
+    public IdentityInitializerService(IServiceProvider sp, ILogger<IdentityInitializerService> logger)
     {
+        ArgumentNullException.ThrowIfNull(sp);
         _sp = sp;
-        _plan = plan;
         _logger = logger;
+        _plan = sp.GetRequiredService<IdentitySeedPlan>();
         _time = sp.GetService<TimeProvider>() ?? TimeProvider.System;
     }
 
@@ -90,26 +99,35 @@ public sealed class IdentityInitializerService : BackgroundService
 
     private async Task RunAsync(CancellationToken stoppingToken)
     {
-        var steps = _plan.Build();
-        var waitUpTo = _plan.WaitUpTo;
-
-        if (steps.Count == 0)
-        {
-            _logger.LogInformation("Identity seed: nothing declared; ready.");
-            _state = new IdentitySeedState(true, "nothing declared", 0);
-            _completed.TrySetResult();
-            return;
-        }
-
-        _logger.LogInformation(
-            "Identity seed: {Roles} role(s), {Users} user(s), {Custom} custom step(s); per-attempt bound {WaitUpTo}",
-            steps.Count(s => s is RoleStep), steps.Count(s => s is UserStep), steps.Count(s => s is CustomStep), waitUpTo);
+        IReadOnlyList<IdentitySeedStep>? steps = null;
+        var waitUpTo = IdentitySeedBuilder.DefaultWaitUpTo;
 
         for (var attempt = 1; !stoppingToken.IsCancellationRequested; attempt++)
         {
-            var current = "identity read models";
+            // R4: building the plan runs a consumer lambda, so it belongs inside the attempt — an error in it is
+            // logged and retried like any other, never a permanent wedge.
+            var current = "building the seed plan";
             try
             {
+                if (steps is null)
+                {
+                    steps = _plan.Build();
+                    waitUpTo = _plan.WaitUpTo;
+
+                    if (steps.Count == 0)
+                    {
+                        _logger.LogInformation("Identity seed: nothing declared; ready.");
+                        _state = new IdentitySeedState(true, "nothing declared", 0);
+                        _completed.TrySetResult();
+                        return;
+                    }
+
+                    _logger.LogInformation(
+                        "Identity seed: {Roles} role(s), {Users} user(s), {Custom} custom step(s); per-attempt bound {WaitUpTo}",
+                        steps.Count(s => s is RoleStep), steps.Count(s => s is UserStep), steps.Count(s => s is CustomStep), waitUpTo);
+                }
+
+                current = "identity read models";
                 _state = new IdentitySeedState(false, $"attempt {attempt}: waiting for identity read models", attempt, _state.LastError);
                 _logger.LogDebug(
                     "Identity seed attempt {Attempt}: waiting for identity read models (RolesModel, UsersModel, UserAuthorizationModel)",
@@ -122,7 +140,7 @@ public sealed class IdentityInitializerService : BackgroundService
                     scope.ServiceProvider.GetRequiredService<UserManager<User>>(),
                     scope.ServiceProvider.GetRequiredService<RoleManager<Role>>(),
                     scope.ServiceProvider.GetRequiredService<IUserStore<User>>(),
-                    roles, users, userAuth, waitUpTo, _time, _logger);
+                    roles, users, userAuth, _written, waitUpTo, _time, _logger);
 
                 foreach (var step in steps)
                 {

--- a/src/MicroPlumberd.Service.Identity/IdentityInitializerService.cs
+++ b/src/MicroPlumberd.Service.Identity/IdentityInitializerService.cs
@@ -43,9 +43,15 @@ public class IdentityInitializerService : BackgroundService
     /// </summary>
     /// <param name="sp">Root service provider; a scope is created per attempt.</param>
     /// <param name="logger">Logger.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="sp"/> or <paramref name="logger"/> is null.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// No seed plan is registered. Register one with <c>AddIdentitySeed(...)</c> or
+    /// <c>AddIdentityInitializer(...)</c> — they register the plan and this hosted service together.
+    /// </exception>
     public IdentityInitializerService(IServiceProvider sp, ILogger<IdentityInitializerService> logger)
     {
         ArgumentNullException.ThrowIfNull(sp);
+        ArgumentNullException.ThrowIfNull(logger);
         _sp = sp;
         _logger = logger;
         _plan = sp.GetRequiredService<IdentitySeedPlan>();

--- a/src/MicroPlumberd.Service.Identity/IdentityInitializerService.cs
+++ b/src/MicroPlumberd.Service.Identity/IdentityInitializerService.cs
@@ -121,6 +121,7 @@ public sealed class IdentityInitializerService : BackgroundService
                 var ctx = new IdentitySeedContext(
                     scope.ServiceProvider.GetRequiredService<UserManager<User>>(),
                     scope.ServiceProvider.GetRequiredService<RoleManager<Role>>(),
+                    scope.ServiceProvider.GetRequiredService<IUserStore<User>>(),
                     roles, users, userAuth, waitUpTo, _time, _logger);
 
                 foreach (var step in steps)

--- a/src/MicroPlumberd.Service.Identity/IdentityInitializerService.cs
+++ b/src/MicroPlumberd.Service.Identity/IdentityInitializerService.cs
@@ -3,137 +3,207 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 
 namespace MicroPlumberd.Services.Identity;
 
 /// <summary>
-/// Background service that initializes the identity system on application startup.
-/// Creates an admin user and role if no users exist in the admin role.
+/// Runs the declared identity seed (see <c>AddIdentitySeed</c>) once the identity read models are live, and
+/// converges the store to it.
+/// <para>
+/// Three invariants (feature-001 requirements R3–R5):
+/// it starts on <b>readiness</b> — <see cref="ICaughtUpHandler.CaughtUp"/> of <see cref="RolesModel"/>,
+/// <see cref="UsersModel"/> and <c>UserAuthorizationModel</c> — never on a timer;
+/// it <b>never stops the host</b> — no exception escapes <see cref="ExecuteAsync"/>, a failed attempt logs Error
+/// and is retried with bounded backoff, which holds even with the .NET default
+/// <c>BackgroundServiceExceptionBehavior.StopHost</c>;
+/// and its progress is <b>observable</b> through <see cref="State"/> and the opt-in <c>identity</c> health check.
+/// </para>
 /// </summary>
-public class IdentityInitializerService : BackgroundService
+public sealed class IdentityInitializerService : BackgroundService
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly UserAuthorizationModel _userAuthorizationModel;
-    private readonly RolesModel _rolesModel;
-    private readonly IdentityInitializerOptions _options;
+    private readonly IServiceProvider _sp;
+    private readonly IdentitySeedPlan _plan;
     private readonly ILogger<IdentityInitializerService> _logger;
+    private readonly TimeProvider _time;
+    private readonly TaskCompletionSource _completed = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private volatile IdentitySeedState _state = new(false, "not started", 0);
 
-    public IdentityInitializerService(
-        IServiceProvider serviceProvider,
-        UserAuthorizationModel userAuthorizationModel,
-        RolesModel rolesModel,
-        IOptions<IdentityInitializerOptions> options,
-        ILogger<IdentityInitializerService> logger)
+    /// <summary>
+    /// Creates the runner. <see cref="TimeProvider"/> is resolved from DI when registered so tests can compress
+    /// the backoff; otherwise <see cref="TimeProvider.System"/> is used.
+    /// </summary>
+    /// <param name="sp">Root service provider; a scope is created per attempt.</param>
+    /// <param name="plan">The accumulated seed declarations.</param>
+    /// <param name="logger">Logger.</param>
+    internal IdentityInitializerService(IServiceProvider sp, IdentitySeedPlan plan, ILogger<IdentityInitializerService> logger)
     {
-        _serviceProvider = serviceProvider;
-        _userAuthorizationModel = userAuthorizationModel;
-        _rolesModel = rolesModel;
-        _options = options.Value;
+        _sp = sp;
+        _plan = plan;
         _logger = logger;
+        _time = sp.GetService<TimeProvider>() ?? TimeProvider.System;
     }
 
+    /// <summary>
+    /// Live snapshot of the seed's progress. Read by the opt-in <c>identity</c> health check.
+    /// </summary>
+    public IdentitySeedState State => _state;
+
+    /// <summary>
+    /// Completes when the seed converged (or when nothing was declared). Never faults — a failing seed keeps
+    /// retrying, so this task simply stays incomplete. Intended for tests and start-up gates.
+    /// </summary>
+    public Task Completed => _completed.Task;
+
+    /// <summary>
+    /// The bounded retry backoff of requirement R4: 1, 2, 5, 10, 20, then 30 seconds for every further attempt.
+    /// </summary>
+    /// <param name="attempt">1-based attempt number that just failed.</param>
+    /// <returns>How long to wait before the next attempt.</returns>
+    public static TimeSpan Backoff(int attempt) => TimeSpan.FromSeconds(attempt switch
+    {
+        <= 1 => 1,
+        2 => 2,
+        3 => 5,
+        4 => 10,
+        5 => 20,
+        _ => 30
+    });
+
+    /// <inheritdoc/>
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        if (!_options.SeedAdminUser)
+        // R4: the outer catch is the invariant. Whatever happens below, the host stays up.
+        try
         {
-            _logger.LogInformation("Admin user seeding is disabled");
+            await RunAsync(stoppingToken);
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            _logger.LogInformation("Identity seed cancelled (host stopping).");
+        }
+        catch (Exception ex)
+        {
+            _state = new IdentitySeedState(false, $"seed runner terminated: {ex.Message}", _state.Attempts, ex.Message);
+            _logger.LogError(ex, "Identity seed runner terminated unexpectedly; the host stays up, /health reports identity Unhealthy.");
+        }
+    }
+
+    private async Task RunAsync(CancellationToken stoppingToken)
+    {
+        var steps = _plan.Build();
+        var waitUpTo = _plan.WaitUpTo;
+
+        if (steps.Count == 0)
+        {
+            _logger.LogInformation("Identity seed: nothing declared; ready.");
+            _state = new IdentitySeedState(true, "nothing declared", 0);
+            _completed.TrySetResult();
             return;
         }
 
-        _logger.LogInformation("Waiting {WaitTime} for projections to catch up before checking for users",
-            _options.ProjectionWaitTime);
+        _logger.LogInformation(
+            "Identity seed: {Roles} role(s), {Users} user(s), {Custom} custom step(s); per-attempt bound {WaitUpTo}",
+            steps.Count(s => s is RoleStep), steps.Count(s => s is UserStep), steps.Count(s => s is CustomStep), waitUpTo);
+
+        for (var attempt = 1; !stoppingToken.IsCancellationRequested; attempt++)
+        {
+            var current = "identity read models";
+            try
+            {
+                _state = new IdentitySeedState(false, $"attempt {attempt}: waiting for identity read models", attempt, _state.LastError);
+                _logger.LogDebug(
+                    "Identity seed attempt {Attempt}: waiting for identity read models (RolesModel, UsersModel, UserAuthorizationModel)",
+                    attempt);
+
+                var (roles, users, userAuth) = await WaitForReadModelsAsync(waitUpTo, stoppingToken);
+
+                using var scope = _sp.CreateScope();
+                var ctx = new IdentitySeedContext(
+                    scope.ServiceProvider.GetRequiredService<UserManager<User>>(),
+                    scope.ServiceProvider.GetRequiredService<RoleManager<Role>>(),
+                    roles, users, userAuth, waitUpTo, _time, _logger);
+
+                foreach (var step in steps)
+                {
+                    current = step.Label;
+                    _state = new IdentitySeedState(false, $"attempt {attempt}: {step.Label}", attempt, _state.LastError);
+                    await RunStepAsync(ctx, step, stoppingToken);
+                }
+
+                _state = new IdentitySeedState(true, $"{steps.Count} step(s) converged", attempt);
+                _logger.LogInformation("Identity seed converged after {Attempts} attempt(s): {Summary}",
+                    attempt, string.Join(", ", steps.Select(s => s.Label)));
+                _completed.TrySetResult();
+                return;
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                _logger.LogInformation("Identity seed cancelled (host stopping) at attempt {Attempt}", attempt);
+                _state = _state with { Description = "cancelled (host stopping)" };
+                return;
+            }
+            catch (Exception ex)
+            {
+                var backoff = Backoff(attempt);
+                _state = new IdentitySeedState(false,
+                    $"attempt {attempt} failed at {current}: {ex.Message} — retry in {backoff}", attempt, ex.Message);
+                _logger.LogError(ex,
+                    "Identity seed attempt {Attempt} failed at {Step}: {Message}; the host stays up, /health reports identity Unhealthy; retrying in {Backoff}",
+                    attempt, current, ex.Message, backoff);
+
+                try
+                {
+                    await Task.Delay(backoff, _time, stoppingToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    _logger.LogInformation("Identity seed cancelled (host stopping) at attempt {Attempt}", attempt);
+                    _state = _state with { Description = "cancelled (host stopping)" };
+                    return;
+                }
+            }
+        }
+
+        _logger.LogInformation("Identity seed cancelled (host stopping) at attempt {Attempt}", _state.Attempts);
+        _state = _state with { Description = "cancelled (host stopping)" };
+    }
+
+    private static Task RunStepAsync(IIdentitySeedContext ctx, IdentitySeedStep step, CancellationToken ct) => step switch
+    {
+        RoleStep r => ctx.EnsureRoleAsync(r.Name, ct),
+        UserStep u => RunUserStepAsync(ctx, u, ct),
+        CustomStep c => c.Action(ctx, ct),
+        _ => throw new NotSupportedException($"Unknown seed step '{step.GetType().Name}'.")
+    };
+
+    private static async Task RunUserStepAsync(IIdentitySeedContext ctx, UserStep step, CancellationToken ct)
+    {
+        var user = await ctx.EnsureUserAsync(step.Email, step.UserName, step.Password, ct);
+        foreach (var role in step.Roles)
+            await ctx.EnsureInRoleAsync(user, role, ct);
+    }
+
+    /// <summary>
+    /// Readiness wait (design.md §4.1). <c>Live</c> completes once and stays completed, so a later attempt after
+    /// a compressed bound succeeds immediately.
+    /// </summary>
+    private async Task<(RolesModel Roles, UsersModel Users, UserAuthorizationModel UserAuth)> WaitForReadModelsAsync(
+        TimeSpan waitUpTo, CancellationToken ct)
+    {
+        var roles = _sp.GetRequiredService<RolesModel>();
+        var users = _sp.GetRequiredService<UsersModel>();
+        var userAuth = _sp.GetRequiredService<UserAuthorizationModel>();
 
         try
         {
-            await Task.Delay(_options.ProjectionWaitTime, stoppingToken);
+            await Task.WhenAll(roles.Live, users.Live, userAuth.Live).WaitAsync(waitUpTo, _time, ct);
         }
-        catch (OperationCanceledException)
+        catch (TimeoutException)
         {
-            _logger.LogInformation("Identity initialization cancelled during wait period");
-            return;
-        }
-
-        var normalizedRoleName = _options.AdminRoleName.ToUpperInvariant();
-        var usersInAdminRole = _userAuthorizationModel.GetUsersInRole(normalizedRoleName);
-
-        if (usersInAdminRole.Count > 0)
-        {
-            _logger.LogInformation("Found {UserCount} users in '{RoleName}' role, skipping admin seeding",
-                usersInAdminRole.Count, _options.AdminRoleName);
-            return;
+            throw new TimeoutException(
+                $"Waited {waitUpTo} for the identity read models (RolesModel, UsersModel, UserAuthorizationModel) to catch up; not there yet.");
         }
 
-        _logger.LogInformation("No users found in '{RoleName}' role, creating initial admin user", _options.AdminRoleName);
-
-        // Use a scope for UserManager and RoleManager (they are scoped services)
-        using var scope = _serviceProvider.CreateScope();
-        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<User>>();
-        var roleManager = scope.ServiceProvider.GetRequiredService<RoleManager<Role>>();
-
-        await CreateAdminRoleAsync(roleManager, stoppingToken);
-        await CreateAdminUserAsync(userManager, stoppingToken);
-    }
-
-    private async Task CreateAdminRoleAsync(RoleManager<Role> roleManager, CancellationToken stoppingToken)
-    {
-        var normalizedRoleName = _options.AdminRoleName.ToUpperInvariant();
-        var existingRole = _rolesModel.GetByNormalizedName(normalizedRoleName);
-
-        if (existingRole != null)
-        {
-            _logger.LogDebug("Admin role '{RoleName}' already exists", _options.AdminRoleName);
-            return;
-        }
-
-        var role = new Role { Name = _options.AdminRoleName };
-        var result = await roleManager.CreateAsync(role);
-
-        if (result.Succeeded)
-        {
-            _logger.LogInformation("Created admin role '{RoleName}'", _options.AdminRoleName);
-        }
-        else
-        {
-            var errors = string.Join(", ", result.Errors.Select(e => e.Description));
-            _logger.LogError("Failed to create admin role '{RoleName}': {Errors}",
-                _options.AdminRoleName, errors);
-        }
-    }
-
-    private async Task CreateAdminUserAsync(UserManager<User> userManager, CancellationToken stoppingToken)
-    {
-        var adminUser = new User
-        {
-            UserName = _options.AdminUserName,
-            Email = _options.AdminEmail,
-            EmailConfirmed = true
-        };
-
-        var createResult = await userManager.CreateAsync(adminUser, _options.AdminPassword);
-
-        if (!createResult.Succeeded)
-        {
-            var errors = string.Join(", ", createResult.Errors.Select(e => e.Description));
-            _logger.LogError("Failed to create admin user '{Email}': {Errors}",
-                _options.AdminEmail, errors);
-            return;
-        }
-
-        _logger.LogInformation("Created admin user with email '{Email}'", _options.AdminEmail);
-
-        // Assign admin role
-        var roleResult = await userManager.AddToRoleAsync(adminUser, _options.AdminRoleName);
-
-        if (roleResult.Succeeded)
-        {
-            _logger.LogInformation("Assigned admin user to role '{RoleName}'", _options.AdminRoleName);
-        }
-        else
-        {
-            var errors = string.Join(", ", roleResult.Errors.Select(e => e.Description));
-            _logger.LogError("Failed to assign admin user to role '{RoleName}': {Errors}",
-                _options.AdminRoleName, errors);
-        }
+        return (roles, users, userAuth);
     }
 }

--- a/src/MicroPlumberd.Service.Identity/IdentitySeedBuilder.cs
+++ b/src/MicroPlumberd.Service.Identity/IdentitySeedBuilder.cs
@@ -1,7 +1,3 @@
-using System.Runtime.CompilerServices;
-
-[assembly: InternalsVisibleTo("MicroPlumberd.Tests")]
-
 namespace MicroPlumberd.Services.Identity;
 
 /// <summary>
@@ -84,12 +80,12 @@ public sealed class IdentitySeedBuilder
     /// retry and health rules as the declarative steps.
     /// </summary>
     /// <param name="step">The step. Everything it throws fails the attempt and is retried with backoff.</param>
-    /// <param name="label">Optional human readable label; defaults to <c>custom step #n</c>.</param>
+    /// <param name="label">Optional human readable label; defaults to <c>custom step #n</c>, counting custom steps only.</param>
     /// <returns>The builder, for chaining.</returns>
     public IdentitySeedBuilder Then(Func<IIdentitySeedContext, CancellationToken, Task> step, string? label = null)
     {
         ArgumentNullException.ThrowIfNull(step);
-        _steps.Add(new CustomStep(step, label ?? $"custom step #{_steps.Count + 1}"));
+        _steps.Add(new CustomStep(step, label ?? $"custom step #{_steps.Count(x => x is CustomStep) + 1}"));
         return this;
     }
 

--- a/src/MicroPlumberd.Service.Identity/IdentitySeedBuilder.cs
+++ b/src/MicroPlumberd.Service.Identity/IdentitySeedBuilder.cs
@@ -1,0 +1,166 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("MicroPlumberd.Tests")]
+
+namespace MicroPlumberd.Services.Identity;
+
+/// <summary>
+/// A single unit of the seed plan. Every step knows the human readable label used in
+/// <see cref="IdentitySeedState.Description"/> and in the log (feature-001 design.md §2).
+/// </summary>
+/// <param name="Label">Human readable label, e.g. <c>role 'Administrator'</c>.</param>
+internal abstract record IdentitySeedStep(string Label);
+
+/// <summary>Ensures a role exists.</summary>
+internal sealed record RoleStep(string Name) : IdentitySeedStep($"role '{Name}'");
+
+/// <summary>Ensures a user exists and is a member of the declared roles.</summary>
+internal sealed record UserStep(string Email, string UserName, string? Password, IReadOnlyList<string> Roles)
+    : IdentitySeedStep($"user '{Email}'");
+
+/// <summary>Runs a consumer supplied step under the same readiness, retry and health rules.</summary>
+internal sealed record CustomStep(Func<IIdentitySeedContext, CancellationToken, Task> Action, string Label)
+    : IdentitySeedStep(Label);
+
+/// <summary>
+/// Declarative, fluent collector of the identity state that must exist after start-up
+/// (feature-001 requirement R1). The library knows no role name and no user name of its own:
+/// everything is declared by the consumer.
+/// </summary>
+/// <example>
+/// <code>
+/// services.AddIdentitySeed(seed => seed
+///     .Role("Administrator")
+///     .User("admin@localhost", u => u.WithUserName("admin").WithPassword(pwd).InRoles("Administrator"))
+///     .WaitUpTo(TimeSpan.FromSeconds(30)));
+/// </code>
+/// </example>
+public sealed class IdentitySeedBuilder
+{
+    /// <summary>
+    /// Default per-attempt readiness bound used when the consumer never calls <see cref="WaitUpTo"/>: 30 seconds.
+    /// </summary>
+    public static readonly TimeSpan DefaultWaitUpTo = TimeSpan.FromSeconds(30);
+
+    private readonly List<IdentitySeedStep> _steps = new();
+    private TimeSpan _waitUpTo = DefaultWaitUpTo;
+
+    internal IReadOnlyList<IdentitySeedStep> Steps => _steps;
+
+    internal TimeSpan WaitUpToValue => _waitUpTo;
+
+    /// <summary>
+    /// Declares that a role with this name must exist. Ensure semantics (R2): the role is created when absent,
+    /// never renamed and never deleted. Removing the declaration leaves the role alone.
+    /// </summary>
+    /// <param name="name">Role name as the consumer wants it stored (the normalized name is derived from it).</param>
+    /// <returns>The builder, for chaining.</returns>
+    public IdentitySeedBuilder Role(string name)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        _steps.Add(new RoleStep(name));
+        return this;
+    }
+
+    /// <summary>
+    /// Declares that a user with this e-mail must exist and be a member of the roles configured on the
+    /// <see cref="IdentitySeedUserBuilder"/>. Ensure semantics (R2): an existing user is returned untouched —
+    /// no password reset, no role removal.
+    /// </summary>
+    /// <param name="email">The user's e-mail; also the lookup key.</param>
+    /// <param name="configure">Optional configuration: user name, password, roles. User name defaults to the e-mail.</param>
+    /// <returns>The builder, for chaining.</returns>
+    public IdentitySeedBuilder User(string email, Action<IdentitySeedUserBuilder>? configure = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(email);
+        var b = new IdentitySeedUserBuilder(email);
+        configure?.Invoke(b);
+        _steps.Add(new UserStep(email, b.UserNameValue ?? email, b.PasswordValue, b.RolesValue));
+        return this;
+    }
+
+    /// <summary>
+    /// Escape hatch (R6): runs a consumer supplied step after the read models are live, under the same
+    /// retry and health rules as the declarative steps.
+    /// </summary>
+    /// <param name="step">The step. Everything it throws fails the attempt and is retried with backoff.</param>
+    /// <param name="label">Optional human readable label; defaults to <c>custom step #n</c>.</param>
+    /// <returns>The builder, for chaining.</returns>
+    public IdentitySeedBuilder Then(Func<IIdentitySeedContext, CancellationToken, Task> step, string? label = null)
+    {
+        ArgumentNullException.ThrowIfNull(step);
+        _steps.Add(new CustomStep(step, label ?? $"custom step #{_steps.Count + 1}"));
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the per-attempt readiness bound (R3): how long one attempt may wait for the identity read models
+    /// to catch up, and how long each write may wait to become visible in the read model the next step reads.
+    /// Expiry fails the attempt, never the host. Last call wins when several declarations are accumulated.
+    /// </summary>
+    /// <param name="bound">The bound. Must be greater than zero.</param>
+    /// <returns>The builder, for chaining.</returns>
+    public IdentitySeedBuilder WaitUpTo(TimeSpan bound)
+    {
+        if (bound <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(bound), bound, "The per-attempt bound must be greater than zero.");
+        _waitUpTo = bound;
+        return this;
+    }
+}
+
+/// <summary>
+/// Fluent configuration of one declared user (see <see cref="IdentitySeedBuilder.User"/>).
+/// </summary>
+public sealed class IdentitySeedUserBuilder
+{
+    private readonly List<string> _roles = new();
+
+    internal IdentitySeedUserBuilder(string email) => Email = email;
+
+    internal string Email { get; }
+    internal string? UserNameValue { get; private set; }
+    internal string? PasswordValue { get; private set; }
+    internal IReadOnlyList<string> RolesValue => _roles;
+
+    /// <summary>Sets the user name. Defaults to the e-mail when not called.</summary>
+    /// <param name="userName">The user name.</param>
+    /// <returns>The builder, for chaining.</returns>
+    public IdentitySeedUserBuilder WithUserName(string userName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(userName);
+        UserNameValue = userName;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the password used when the user is created. When not called the user is created without a
+    /// password — an external-login-only account.
+    /// </summary>
+    /// <param name="password">The password.</param>
+    /// <returns>The builder, for chaining.</returns>
+    public IdentitySeedUserBuilder WithPassword(string password)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(password);
+        PasswordValue = password;
+        return this;
+    }
+
+    /// <summary>
+    /// Declares role membership. Additive: calling it twice accumulates. A role named here that was not
+    /// declared with <see cref="IdentitySeedBuilder.Role"/> is ensured before the membership is assigned.
+    /// </summary>
+    /// <param name="roles">Role names.</param>
+    /// <returns>The builder, for chaining.</returns>
+    public IdentitySeedUserBuilder InRoles(params string[] roles)
+    {
+        ArgumentNullException.ThrowIfNull(roles);
+        foreach (var r in roles)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(r);
+            if (!_roles.Contains(r))
+                _roles.Add(r);
+        }
+        return this;
+    }
+}

--- a/src/MicroPlumberd.Service.Identity/IdentitySeedContext.cs
+++ b/src/MicroPlumberd.Service.Identity/IdentitySeedContext.cs
@@ -60,6 +60,7 @@ internal sealed class IdentitySeedContext : IIdentitySeedContext
     /// <summary>How often a read-your-write wait re-checks visibility.</summary>
     internal static readonly TimeSpan PollInterval = TimeSpan.FromMilliseconds(100);
 
+    private readonly IUserEmailStore<User>? _emailStore;
     private readonly RolesModel _roles;
     private readonly UsersModel _users;
     private readonly UserAuthorizationModel _userAuth;
@@ -69,6 +70,7 @@ internal sealed class IdentitySeedContext : IIdentitySeedContext
     public IdentitySeedContext(
         UserManager<User> userManager,
         RoleManager<Role> roleManager,
+        IUserStore<User> userStore,
         RolesModel roles,
         UsersModel users,
         UserAuthorizationModel userAuth,
@@ -78,6 +80,7 @@ internal sealed class IdentitySeedContext : IIdentitySeedContext
     {
         UserManager = userManager;
         RoleManager = roleManager;
+        _emailStore = userStore as IUserEmailStore<User>;
         _roles = roles;
         _users = users;
         _userAuth = userAuth;
@@ -157,6 +160,16 @@ internal sealed class IdentitySeedContext : IIdentitySeedContext
 
         await UntilAsync(() => _users.GetByNormalizedEmail(normalizedEmail) is not null,
             $"{label} to become visible in UsersModel", ct);
+
+        // UserStore.CreateAsync does not carry User.EmailConfirmed into the aggregate (a profile is created
+        // unconfirmed), so a seeded user has to be confirmed with its own write. Only on creation: an existing
+        // user is never modified (R2).
+        if (_users.GetByNormalizedEmail(normalizedEmail) is { EmailConfirmed: false } fresh && _emailStore is not null)
+        {
+            await _emailStore.SetEmailConfirmedAsync(fresh, true, ct);
+            await UntilAsync(() => _users.GetByNormalizedEmail(normalizedEmail) is { EmailConfirmed: true },
+                $"{label} e-mail confirmation to become visible in UsersModel", ct);
+        }
 
         return _users.GetByNormalizedEmail(normalizedEmail)!;
     }

--- a/src/MicroPlumberd.Service.Identity/IdentitySeedContext.cs
+++ b/src/MicroPlumberd.Service.Identity/IdentitySeedContext.cs
@@ -1,0 +1,235 @@
+using MicroPlumberd.Services.Identity.ReadModels;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
+
+namespace MicroPlumberd.Services.Identity;
+
+/// <summary>
+/// The API a seed step works against (feature-001 requirement R6). Every <c>Ensure…</c> is idempotent and
+/// carries the read-your-own-write wait: it does not return until its own write is visible in the read model
+/// the next step reads, bounded by the per-attempt bound (<see cref="IdentitySeedBuilder.WaitUpTo"/>).
+/// </summary>
+public interface IIdentitySeedContext
+{
+    /// <summary>The scoped <see cref="UserManager{TUser}"/> of the current attempt.</summary>
+    UserManager<User> UserManager { get; }
+
+    /// <summary>The scoped <see cref="RoleManager{TRole}"/> of the current attempt.</summary>
+    RoleManager<Role> RoleManager { get; }
+
+    /// <summary>The seed's logger, so a consumer step logs on the same seam as the library.</summary>
+    ILogger Logger { get; }
+
+    /// <summary>
+    /// Ensures a role with this name exists, then waits until it is visible in <see cref="RolesModel"/>.
+    /// </summary>
+    /// <param name="name">Role name.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <exception cref="TimeoutException">The write did not become visible within the per-attempt bound.</exception>
+    Task EnsureRoleAsync(string name, CancellationToken ct = default);
+
+    /// <summary>
+    /// Ensures a user with this e-mail exists (<c>EmailConfirmed = true</c>), then waits until it is visible in
+    /// <see cref="UsersModel"/>. An existing user is returned untouched — no password reset, no role removal (R2).
+    /// </summary>
+    /// <param name="email">E-mail; also the lookup key.</param>
+    /// <param name="userName">User name; defaults to the e-mail when null.</param>
+    /// <param name="password">Password; when null the user is created without one (external-login-only account).</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The existing or freshly created user, as held by <see cref="UsersModel"/>.</returns>
+    /// <exception cref="TimeoutException">The write did not become visible within the per-attempt bound.</exception>
+    Task<User> EnsureUserAsync(string email, string? userName = null, string? password = null, CancellationToken ct = default);
+
+    /// <summary>
+    /// Ensures the user is a member of the role (ensuring the role itself first), then waits until the
+    /// membership is visible in <c>UserAuthorizationModel</c>.
+    /// </summary>
+    /// <param name="user">The user.</param>
+    /// <param name="role">Role name.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <exception cref="TimeoutException">The write did not become visible within the per-attempt bound.</exception>
+    Task EnsureInRoleAsync(User user, string role, CancellationToken ct = default);
+}
+
+/// <summary>
+/// The per-attempt implementation of <see cref="IIdentitySeedContext"/>, living inside one DI scope
+/// (feature-001 design.md §4).
+/// </summary>
+internal sealed class IdentitySeedContext : IIdentitySeedContext
+{
+    /// <summary>How often a read-your-write wait re-checks visibility.</summary>
+    internal static readonly TimeSpan PollInterval = TimeSpan.FromMilliseconds(100);
+
+    private readonly RolesModel _roles;
+    private readonly UsersModel _users;
+    private readonly UserAuthorizationModel _userAuth;
+    private readonly TimeSpan _waitUpTo;
+    private readonly TimeProvider _time;
+
+    public IdentitySeedContext(
+        UserManager<User> userManager,
+        RoleManager<Role> roleManager,
+        RolesModel roles,
+        UsersModel users,
+        UserAuthorizationModel userAuth,
+        TimeSpan waitUpTo,
+        TimeProvider time,
+        ILogger logger)
+    {
+        UserManager = userManager;
+        RoleManager = roleManager;
+        _roles = roles;
+        _users = users;
+        _userAuth = userAuth;
+        _waitUpTo = waitUpTo;
+        _time = time;
+        Logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public UserManager<User> UserManager { get; }
+
+    /// <inheritdoc/>
+    public RoleManager<Role> RoleManager { get; }
+
+    /// <inheritdoc/>
+    public ILogger Logger { get; }
+
+    /// <inheritdoc/>
+    public async Task EnsureRoleAsync(string name, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        var normalized = Normalize(name);
+        var label = $"role '{name}'";
+
+        if (_roles.GetByNormalizedName(normalized) is null)
+        {
+            Logger.LogInformation("Identity seed: ensuring {Step}", label);
+            var result = await RoleManager.CreateAsync(new Role { Name = name });
+            if (result.Succeeded)
+                Logger.LogInformation("Identity seed: created {Step}", label);
+            else if (IsAlreadyThere(result))
+                Logger.LogInformation("Identity seed: {Step} was created concurrently: {Errors}", label, Describe(result));
+            else
+                throw new InvalidOperationException($"Could not create {label}: {Describe(result)}");
+        }
+        else
+        {
+            Logger.LogInformation("Identity seed: {Step} already present", label);
+        }
+
+        await UntilAsync(() => _roles.GetByNormalizedName(normalized) is not null,
+            $"{label} to become visible in RolesModel", ct);
+    }
+
+    /// <inheritdoc/>
+    public async Task<User> EnsureUserAsync(string email, string? userName = null, string? password = null, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(email);
+        var normalizedEmail = Normalize(email);
+        var label = $"user '{email}'";
+
+        var existing = _users.GetByNormalizedEmail(normalizedEmail);
+        if (existing is not null)
+        {
+            Logger.LogInformation("Identity seed: {Step} already present", label);
+            return existing;
+        }
+
+        Logger.LogInformation("Identity seed: ensuring {Step}", label);
+        var user = new User
+        {
+            UserName = userName ?? email,
+            Email = email,
+            EmailConfirmed = true
+        };
+
+        var result = password is null
+            ? await UserManager.CreateAsync(user)
+            : await UserManager.CreateAsync(user, password);
+
+        if (result.Succeeded)
+            Logger.LogInformation("Identity seed: created {Step}", label);
+        else if (IsAlreadyThere(result))
+            Logger.LogInformation("Identity seed: {Step} was created concurrently: {Errors}", label, Describe(result));
+        else
+            throw new InvalidOperationException($"Could not create {label}: {Describe(result)}");
+
+        await UntilAsync(() => _users.GetByNormalizedEmail(normalizedEmail) is not null,
+            $"{label} to become visible in UsersModel", ct);
+
+        return _users.GetByNormalizedEmail(normalizedEmail)!;
+    }
+
+    /// <inheritdoc/>
+    public async Task EnsureInRoleAsync(User user, string role, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(user);
+        ArgumentException.ThrowIfNullOrWhiteSpace(role);
+
+        // The membership write reads the role out of RolesModel (UserStore.AddToRoleAsync); ensure it first so
+        // "Role 'X' does not exist" cannot happen. Idempotent when the role step already ran.
+        await EnsureRoleAsync(role, ct);
+
+        var normalizedRole = Normalize(role);
+        var userId = UserIdentifier.Parse(user.Id, null);
+        var label = $"user '{user.Email}' in role '{role}'";
+
+        if (!_userAuth.IsInRole(userId, normalizedRole))
+        {
+            Logger.LogInformation("Identity seed: ensuring {Step}", label);
+            var result = await UserManager.AddToRoleAsync(user, role);
+            if (result.Succeeded)
+                Logger.LogInformation("Identity seed: created {Step}", label);
+            else if (IsAlreadyThere(result))
+                Logger.LogInformation("Identity seed: {Step} was assigned concurrently: {Errors}", label, Describe(result));
+            else
+                throw new InvalidOperationException($"Could not assign {label}: {Describe(result)}");
+        }
+        else
+        {
+            Logger.LogInformation("Identity seed: {Step} already present", label);
+        }
+
+        await UntilAsync(() => _userAuth.IsInRole(userId, normalizedRole),
+            $"{label} to become visible in UserAuthorizationModel", ct);
+    }
+
+    /// <summary>
+    /// Read-your-own-write wait (design.md §4): checks first, then polls until <paramref name="visible"/> holds
+    /// or the per-attempt bound expires.
+    /// </summary>
+    private async Task UntilAsync(Func<bool> visible, string what, CancellationToken ct)
+    {
+        if (visible()) return;
+
+        using var deadline = new CancellationTokenSource(_waitUpTo, _time);
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct, deadline.Token);
+
+        while (true)
+        {
+            try
+            {
+                await Task.Delay(PollInterval, _time, linked.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                if (visible()) return;
+                ct.ThrowIfCancellationRequested();
+                throw new TimeoutException($"Waited {_waitUpTo} for {what}; not there yet.");
+            }
+
+            if (visible()) return;
+        }
+    }
+
+    private static string Normalize(string value) => value.ToUpperInvariant();
+
+    private static bool IsAlreadyThere(IdentityResult result) =>
+        result.Errors.Any(e =>
+            e.Code is "DuplicateRoleName" or "DuplicateUserName" or "DuplicateEmail" or "UserAlreadyInRole" ||
+            (e.Description?.Contains("already", StringComparison.OrdinalIgnoreCase) ?? false));
+
+    private static string Describe(IdentityResult result) =>
+        string.Join(", ", result.Errors.Select(e => e.Description));
+}

--- a/src/MicroPlumberd.Service.Identity/IdentitySeedContext.cs
+++ b/src/MicroPlumberd.Service.Identity/IdentitySeedContext.cs
@@ -141,6 +141,9 @@ internal sealed class IdentitySeedContext : IIdentitySeedContext
             }
             else if (IsAlreadyThere(result, label))
             {
+                // It exists - another attempt or another host won the race - so a later retry must not try to
+                // create it again. The aggregate id is not ours to know here.
+                _written[key] = string.Empty;
                 Logger.LogInformation("Identity seed: {Step} was created concurrently: {Errors}", label, Describe(result));
             }
             else
@@ -190,6 +193,9 @@ internal sealed class IdentitySeedContext : IIdentitySeedContext
             }
             else if (IsAlreadyThere(result, label))
             {
+                // It exists - another attempt or another host won the race - so a later retry must not try to
+                // create it again. The aggregate id is not ours to know here.
+                _written[key] = string.Empty;
                 Logger.LogInformation("Identity seed: {Step} was created concurrently: {Errors}", label, Describe(result));
             }
             else
@@ -240,6 +246,8 @@ internal sealed class IdentitySeedContext : IIdentitySeedContext
             }
             else if (IsAlreadyThere(result, label))
             {
+                // The membership exists, so a later retry must not try to assign it again.
+                _written[key] = string.Empty;
                 Logger.LogInformation("Identity seed: {Step} was assigned concurrently: {Errors}", label, Describe(result));
             }
             else

--- a/src/MicroPlumberd.Service.Identity/IdentitySeedContext.cs
+++ b/src/MicroPlumberd.Service.Identity/IdentitySeedContext.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using MicroPlumberd.Services.Identity.ReadModels;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Logging;
@@ -29,14 +30,17 @@ public interface IIdentitySeedContext
     Task EnsureRoleAsync(string name, CancellationToken ct = default);
 
     /// <summary>
-    /// Ensures a user with this e-mail exists (<c>EmailConfirmed = true</c>), then waits until it is visible in
-    /// <see cref="UsersModel"/>. An existing user is returned untouched — no password reset, no role removal (R2).
+    /// Ensures a user with this e-mail exists and has <c>EmailConfirmed = true</c>, then waits until that is
+    /// visible in <see cref="UsersModel"/>. The confirm-only flip false→true is the ONLY write ever applied to an
+    /// existing user — no password reset, no user-name change, no role removal (R2).
     /// </summary>
     /// <param name="email">E-mail; also the lookup key.</param>
     /// <param name="userName">User name; defaults to the e-mail when null.</param>
     /// <param name="password">Password; when null the user is created without one (external-login-only account).</param>
     /// <param name="ct">Cancellation token.</param>
-    /// <returns>The existing or freshly created user, as held by <see cref="UsersModel"/>.</returns>
+    /// <returns>
+    /// The user as held by <see cref="UsersModel"/>. The returned instance is the read model's own; do not mutate.
+    /// </returns>
     /// <exception cref="TimeoutException">The write did not become visible within the per-attempt bound.</exception>
     Task<User> EnsureUserAsync(string email, string? userName = null, string? password = null, CancellationToken ct = default);
 
@@ -60,12 +64,20 @@ internal sealed class IdentitySeedContext : IIdentitySeedContext
     /// <summary>How often a read-your-write wait re-checks visibility.</summary>
     internal static readonly TimeSpan PollInterval = TimeSpan.FromMilliseconds(100);
 
+    private readonly IUserStore<User> _userStore;
     private readonly IUserEmailStore<User>? _emailStore;
     private readonly RolesModel _roles;
     private readonly UsersModel _users;
     private readonly UserAuthorizationModel _userAuth;
     private readonly TimeSpan _waitUpTo;
     private readonly TimeProvider _time;
+
+    /// <summary>
+    /// Runner-scoped memory of writes that already succeeded, spanning attempts (design.md §4.3). Without it a
+    /// retry after a timed-out visibility wait creates a duplicate: neither <c>RoleStore</c> nor <c>UserStore</c>
+    /// dedupes against anything but the (still unfolded) read model.
+    /// </summary>
+    private readonly ConcurrentDictionary<string, string> _written;
 
     public IdentitySeedContext(
         UserManager<User> userManager,
@@ -74,16 +86,19 @@ internal sealed class IdentitySeedContext : IIdentitySeedContext
         RolesModel roles,
         UsersModel users,
         UserAuthorizationModel userAuth,
+        ConcurrentDictionary<string, string> written,
         TimeSpan waitUpTo,
         TimeProvider time,
         ILogger logger)
     {
         UserManager = userManager;
         RoleManager = roleManager;
+        _userStore = userStore;
         _emailStore = userStore as IUserEmailStore<User>;
         _roles = roles;
         _users = users;
         _userAuth = userAuth;
+        _written = written;
         _waitUpTo = waitUpTo;
         _time = time;
         Logger = logger;
@@ -102,23 +117,36 @@ internal sealed class IdentitySeedContext : IIdentitySeedContext
     public async Task EnsureRoleAsync(string name, CancellationToken ct = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
-        var normalized = Normalize(name);
+        var normalized = NormalizeRole(name);
+        var key = $"role:{normalized}";
         var label = $"role '{name}'";
 
-        if (_roles.GetByNormalizedName(normalized) is null)
+        if (_roles.GetByNormalizedName(normalized) is not null)
         {
-            Logger.LogInformation("Identity seed: ensuring {Step}", label);
-            var result = await RoleManager.CreateAsync(new Role { Name = name });
-            if (result.Succeeded)
-                Logger.LogInformation("Identity seed: created {Step}", label);
-            else if (IsAlreadyThere(result))
-                Logger.LogInformation("Identity seed: {Step} was created concurrently: {Errors}", label, Describe(result));
-            else
-                throw new InvalidOperationException($"Could not create {label}: {Describe(result)}");
+            Logger.LogInformation("Identity seed: {Step} already present", label);
+        }
+        else if (_written.ContainsKey(key))
+        {
+            Logger.LogInformation("Identity seed: {Step} was already created by this runner; waiting for it to become visible", label);
         }
         else
         {
-            Logger.LogInformation("Identity seed: {Step} already present", label);
+            Logger.LogInformation("Identity seed: ensuring {Step}", label);
+            var role = new Role { Name = name };
+            var result = await RoleManager.CreateAsync(role);
+            if (result.Succeeded)
+            {
+                _written[key] = role.Id;
+                Logger.LogInformation("Identity seed: created {Step}", label);
+            }
+            else if (IsAlreadyThere(result, label))
+            {
+                Logger.LogInformation("Identity seed: {Step} was created concurrently: {Errors}", label, Describe(result));
+            }
+            else
+            {
+                throw new InvalidOperationException($"Could not create {label}: {Describe(result)}");
+            }
         }
 
         await UntilAsync(() => _roles.GetByNormalizedName(normalized) is not null,
@@ -129,47 +157,51 @@ internal sealed class IdentitySeedContext : IIdentitySeedContext
     public async Task<User> EnsureUserAsync(string email, string? userName = null, string? password = null, CancellationToken ct = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(email);
-        var normalizedEmail = Normalize(email);
+        var normalizedEmail = NormalizeEmail(email);
+        var key = $"user:{normalizedEmail}";
         var label = $"user '{email}'";
 
-        var existing = _users.GetByNormalizedEmail(normalizedEmail);
-        if (existing is not null)
+        if (_users.GetByNormalizedEmail(normalizedEmail) is not null)
         {
             Logger.LogInformation("Identity seed: {Step} already present", label);
-            return existing;
         }
-
-        Logger.LogInformation("Identity seed: ensuring {Step}", label);
-        var user = new User
+        else if (_written.ContainsKey(key))
         {
-            UserName = userName ?? email,
-            Email = email,
-            EmailConfirmed = true
-        };
-
-        var result = password is null
-            ? await UserManager.CreateAsync(user)
-            : await UserManager.CreateAsync(user, password);
-
-        if (result.Succeeded)
-            Logger.LogInformation("Identity seed: created {Step}", label);
-        else if (IsAlreadyThere(result))
-            Logger.LogInformation("Identity seed: {Step} was created concurrently: {Errors}", label, Describe(result));
+            Logger.LogInformation("Identity seed: {Step} was already created by this runner; waiting for it to become visible", label);
+        }
         else
-            throw new InvalidOperationException($"Could not create {label}: {Describe(result)}");
+        {
+            Logger.LogInformation("Identity seed: ensuring {Step}", label);
+            var user = new User
+            {
+                UserName = userName ?? email,
+                Email = email,
+                EmailConfirmed = true
+            };
+
+            var result = password is null
+                ? await UserManager.CreateAsync(user)
+                : await UserManager.CreateAsync(user, password);
+
+            if (result.Succeeded)
+            {
+                _written[key] = user.Id;
+                Logger.LogInformation("Identity seed: created {Step}", label);
+            }
+            else if (IsAlreadyThere(result, label))
+            {
+                Logger.LogInformation("Identity seed: {Step} was created concurrently: {Errors}", label, Describe(result));
+            }
+            else
+            {
+                throw new InvalidOperationException($"Could not create {label}: {Describe(result)}");
+            }
+        }
 
         await UntilAsync(() => _users.GetByNormalizedEmail(normalizedEmail) is not null,
             $"{label} to become visible in UsersModel", ct);
 
-        // UserStore.CreateAsync does not carry User.EmailConfirmed into the aggregate (a profile is created
-        // unconfirmed), so a seeded user has to be confirmed with its own write. Only on creation: an existing
-        // user is never modified (R2).
-        if (_users.GetByNormalizedEmail(normalizedEmail) is { EmailConfirmed: false } fresh && _emailStore is not null)
-        {
-            await _emailStore.SetEmailConfirmedAsync(fresh, true, ct);
-            await UntilAsync(() => _users.GetByNormalizedEmail(normalizedEmail) is { EmailConfirmed: true },
-                $"{label} e-mail confirmation to become visible in UsersModel", ct);
-        }
+        await EnsureEmailConfirmedAsync(normalizedEmail, label, ct);
 
         return _users.GetByNormalizedEmail(normalizedEmail)!;
     }
@@ -184,28 +216,66 @@ internal sealed class IdentitySeedContext : IIdentitySeedContext
         // "Role 'X' does not exist" cannot happen. Idempotent when the role step already ran.
         await EnsureRoleAsync(role, ct);
 
-        var normalizedRole = Normalize(role);
+        var normalizedRole = NormalizeRole(role);
         var userId = UserIdentifier.Parse(user.Id, null);
+        var key = $"membership:{user.Id}:{normalizedRole}";
         var label = $"user '{user.Email}' in role '{role}'";
 
-        if (!_userAuth.IsInRole(userId, normalizedRole))
+        if (_userAuth.IsInRole(userId, normalizedRole))
+        {
+            Logger.LogInformation("Identity seed: {Step} already present", label);
+        }
+        else if (_written.ContainsKey(key))
+        {
+            Logger.LogInformation("Identity seed: {Step} was already assigned by this runner; waiting for it to become visible", label);
+        }
+        else
         {
             Logger.LogInformation("Identity seed: ensuring {Step}", label);
             var result = await UserManager.AddToRoleAsync(user, role);
             if (result.Succeeded)
+            {
+                _written[key] = normalizedRole;
                 Logger.LogInformation("Identity seed: created {Step}", label);
-            else if (IsAlreadyThere(result))
+            }
+            else if (IsAlreadyThere(result, label))
+            {
                 Logger.LogInformation("Identity seed: {Step} was assigned concurrently: {Errors}", label, Describe(result));
+            }
             else
+            {
                 throw new InvalidOperationException($"Could not assign {label}: {Describe(result)}");
-        }
-        else
-        {
-            Logger.LogInformation("Identity seed: {Step} already present", label);
+            }
         }
 
         await UntilAsync(() => _userAuth.IsInRole(userId, normalizedRole),
             $"{label} to become visible in UserAuthorizationModel", ct);
+    }
+
+    /// <summary>
+    /// <c>UserStore.CreateAsync</c> does not carry <c>User.EmailConfirmed</c> into <c>UserProfileAggregate</c>, so a
+    /// seeded user is created unconfirmed and needs its own write. This runs for an existing declared user too: the
+    /// confirm-only flip false→true is part of the declared state (R2) and is the only write ever applied to one.
+    /// The aggregate itself is idempotent (<c>ConfirmEmail</c> returns early when already confirmed), so a repeat
+    /// after a timed-out visibility wait appends nothing.
+    /// </summary>
+    private async Task EnsureEmailConfirmedAsync(string normalizedEmail, string label, CancellationToken ct)
+    {
+        if (_users.GetByNormalizedEmail(normalizedEmail) is not { EmailConfirmed: false } unconfirmed)
+            return;
+
+        if (_emailStore is null)
+        {
+            Logger.LogWarning(
+                "Identity seed: {Step} is not e-mail confirmed and the registered IUserStore<User> ({StoreType}) is not an IUserEmailStore<User>; leaving it unconfirmed",
+                label, _userStore.GetType().FullName);
+            return;
+        }
+
+        Logger.LogInformation("Identity seed: confirming the e-mail of {Step}", label);
+        await _emailStore.SetEmailConfirmedAsync(unconfirmed, true, ct);
+        await UntilAsync(() => _users.GetByNormalizedEmail(normalizedEmail) is { EmailConfirmed: true },
+            $"{label} e-mail confirmation to become visible in UsersModel", ct);
     }
 
     /// <summary>
@@ -236,12 +306,31 @@ internal sealed class IdentitySeedContext : IIdentitySeedContext
         }
     }
 
-    private static string Normalize(string value) => value.ToUpperInvariant();
+    /// <summary>
+    /// Normalizes a role name with the registered <see cref="ILookupNormalizer"/>, so the key matches what
+    /// <c>RoleManager.CreateAsync</c> stored in <c>RoleCreated.NormalizedName</c>. Never <c>ToUpperInvariant()</c>:
+    /// a consumer with a custom normalizer would otherwise make every visibility check fail forever.
+    /// </summary>
+    private string NormalizeRole(string name) => RoleManager.NormalizeKey(name) ?? name;
 
-    private static bool IsAlreadyThere(IdentityResult result) =>
-        result.Errors.Any(e =>
-            e.Code is "DuplicateRoleName" or "DuplicateUserName" or "DuplicateEmail" or "UserAlreadyInRole" ||
-            (e.Description?.Contains("already", StringComparison.OrdinalIgnoreCase) ?? false));
+    /// <summary>Normalizes an e-mail with the registered <see cref="ILookupNormalizer"/>.</summary>
+    private string NormalizeEmail(string email) => UserManager.NormalizeEmail(email) ?? email;
+
+    /// <summary>
+    /// A failed <see cref="IdentityResult"/> counts as "someone else already created it" only by
+    /// <see cref="IdentityError.Code"/> — never by message text. A failure carrying no code is logged at Warning
+    /// and treated as a real failure, so the visibility wait cannot mask it.
+    /// </summary>
+    private bool IsAlreadyThere(IdentityResult result, string label)
+    {
+        if (result.Errors.Any(e => e.Code is "DuplicateRoleName" or "DuplicateUserName" or "DuplicateEmail" or "UserAlreadyInRole"))
+            return true;
+
+        foreach (var e in result.Errors.Where(e => string.IsNullOrEmpty(e.Code)))
+            Logger.LogWarning("Identity seed: {Step} failed with an error that carries no code: {Description}", label, e.Description);
+
+        return false;
+    }
 
     private static string Describe(IdentityResult result) =>
         string.Join(", ", result.Errors.Select(e => e.Description));

--- a/src/MicroPlumberd.Service.Identity/IdentitySeedHealthCheck.cs
+++ b/src/MicroPlumberd.Service.Identity/IdentitySeedHealthCheck.cs
@@ -1,0 +1,49 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace MicroPlumberd.Services.Identity;
+
+/// <summary>
+/// Reports <see cref="IdentityInitializerService.State"/> live (feature-001 requirement R5): Unhealthy naming the
+/// current step or the last error until the seed converged, Healthy afterwards.
+/// </summary>
+internal sealed class IdentitySeedHealthCheck : IHealthCheck
+{
+    private readonly IdentityInitializerService _service;
+
+    public IdentitySeedHealthCheck(IdentityInitializerService service) => _service = service;
+
+    /// <inheritdoc/>
+    public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+    {
+        var state = _service.State;
+        var data = new Dictionary<string, object> { ["attempts"] = state.Attempts };
+        if (state.LastError is not null)
+            data["lastError"] = state.LastError;
+
+        return Task.FromResult(state.Ready
+            ? HealthCheckResult.Healthy(state.Description, data)
+            : HealthCheckResult.Unhealthy(state.Description, data: data));
+    }
+}
+
+/// <summary>
+/// Registration of the opt-in identity seed health check.
+/// </summary>
+public static class IdentityHealthCheckExtensions
+{
+    /// <summary>
+    /// Adds the identity seed health check. Opt-in and untagged, so a patch upgrade never adds a
+    /// <c>/health</c> entry to a consumer that did not ask for one (ruling 2 of the requirements).
+    /// </summary>
+    /// <param name="builder">The health checks builder.</param>
+    /// <param name="name">Health entry name. Defaults to <c>identity</c>.</param>
+    /// <returns>The health checks builder for method chaining.</returns>
+    public static IHealthChecksBuilder AddIdentitySeedHealthCheck(this IHealthChecksBuilder builder, string name = "identity")
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ContainerExtensions.RegisterSeedRunner(builder.Services);
+        builder.AddTypeActivatedCheck<IdentitySeedHealthCheck>(name);
+        return builder;
+    }
+}

--- a/src/MicroPlumberd.Service.Identity/IdentitySeedPlan.cs
+++ b/src/MicroPlumberd.Service.Identity/IdentitySeedPlan.cs
@@ -1,0 +1,95 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace MicroPlumberd.Services.Identity;
+
+/// <summary>
+/// One <c>AddIdentitySeed</c> (or <c>AddIdentityInitializer</c>) call, kept in DI so several calls accumulate
+/// in registration order (feature-001 design.md §1).
+/// </summary>
+internal sealed class IdentitySeedDeclaration
+{
+    private readonly Action<IdentitySeedBuilder>? _configure;
+
+    /// <summary>Creates a declaration from an explicit fluent configuration.</summary>
+    public IdentitySeedDeclaration(Action<IdentitySeedBuilder> configure)
+        => _configure = configure ?? throw new ArgumentNullException(nameof(configure));
+
+    private IdentitySeedDeclaration() => IsFromOptions = true;
+
+    /// <summary>
+    /// True for the legacy <c>AddIdentityInitializer</c> adapter: its contribution is read from
+    /// <see cref="IdentityInitializerOptions"/> at run time, because consumers configure it with
+    /// <c>services.Configure(...)</c> after the call.
+    /// </summary>
+    public bool IsFromOptions { get; }
+
+    /// <summary>Creates the legacy adapter declaration (R7).</summary>
+    public static IdentitySeedDeclaration FromOptions() => new();
+
+    /// <summary>Applies this declaration to the shared builder.</summary>
+    public void Apply(IdentitySeedBuilder builder, IServiceProvider sp)
+    {
+        if (!IsFromOptions)
+        {
+            _configure!(builder);
+            return;
+        }
+
+        var o = sp.GetRequiredService<IOptions<IdentityInitializerOptions>>().Value;
+        if (!o.SeedAdminUser)
+            return; // R7: SeedAdminUser = false contributes nothing => empty seed => Ready immediately.
+
+        builder.Role(o.AdminRoleName)
+            .User(o.AdminEmail, u => u
+                .WithUserName(o.AdminUserName)
+                .WithPassword(o.AdminPassword)
+                .InRoles(o.AdminRoleName))
+            .WaitUpTo(o.ProjectionWaitTime);
+    }
+}
+
+/// <summary>
+/// Singleton that turns the accumulated <see cref="IdentitySeedDeclaration"/>s into an ordered, immutable plan.
+/// Built lazily on first use inside <see cref="IdentityInitializerService"/> so options configured after the
+/// registration call are honoured.
+/// </summary>
+internal sealed class IdentitySeedPlan
+{
+    private readonly IEnumerable<IdentitySeedDeclaration> _declarations;
+    private readonly IServiceProvider _sp;
+    private readonly Lock _gate = new();
+    private IReadOnlyList<IdentitySeedStep>? _steps;
+    private TimeSpan _waitUpTo = IdentitySeedBuilder.DefaultWaitUpTo;
+
+    public IdentitySeedPlan(IEnumerable<IdentitySeedDeclaration> declarations, IServiceProvider sp)
+    {
+        _declarations = declarations;
+        _sp = sp;
+    }
+
+    /// <summary>The per-attempt readiness bound of the built plan. Valid after <see cref="Build"/>.</summary>
+    public TimeSpan WaitUpTo => _waitUpTo;
+
+    /// <summary>Builds (once) and returns the ordered plan.</summary>
+    public IReadOnlyList<IdentitySeedStep> Build()
+    {
+        lock (_gate)
+        {
+            if (_steps is not null) return _steps;
+
+            var builder = new IdentitySeedBuilder();
+            foreach (var d in _declarations)
+                d.Apply(builder, _sp);
+
+            _waitUpTo = builder.WaitUpToValue;
+            return _steps = builder.Steps.ToArray();
+        }
+    }
+}
+
+/// <summary>
+/// Marker used to register the hosted <see cref="IdentityInitializerService"/> exactly once, however many
+/// times <c>AddIdentitySeed</c> / <c>AddIdentityInitializer</c> are called.
+/// </summary>
+internal sealed class IdentitySeedHostedMarker;

--- a/src/MicroPlumberd.Service.Identity/IdentitySeedPlan.cs
+++ b/src/MicroPlumberd.Service.Identity/IdentitySeedPlan.cs
@@ -87,9 +87,3 @@ internal sealed class IdentitySeedPlan
         }
     }
 }
-
-/// <summary>
-/// Marker used to register the hosted <see cref="IdentityInitializerService"/> exactly once, however many
-/// times <c>AddIdentitySeed</c> / <c>AddIdentityInitializer</c> are called.
-/// </summary>
-internal sealed class IdentitySeedHostedMarker;

--- a/src/MicroPlumberd.Service.Identity/IdentitySeedState.cs
+++ b/src/MicroPlumberd.Service.Identity/IdentitySeedState.cs
@@ -1,0 +1,12 @@
+namespace MicroPlumberd.Services.Identity;
+
+/// <summary>
+/// Immutable snapshot of the identity seed's progress, published by
+/// <see cref="IdentityInitializerService.State"/> and read live by the optional
+/// <c>identity</c> health check (feature-001 design.md §2, requirement R5).
+/// </summary>
+/// <param name="Ready">True once the declared seed converged (or nothing was declared).</param>
+/// <param name="Description">Human readable description of what the seed is doing, or why it is not ready.</param>
+/// <param name="Attempts">Number of attempts started so far. 0 when nothing was declared.</param>
+/// <param name="LastError">Message of the last failure, or null if no attempt has failed.</param>
+public sealed record IdentitySeedState(bool Ready, string Description, int Attempts, string? LastError = null);

--- a/src/MicroPlumberd.Service.Identity/MicroPlumberd.Services.Identity.csproj
+++ b/src/MicroPlumberd.Service.Identity/MicroPlumberd.Services.Identity.csproj
@@ -22,7 +22,8 @@
 			<Pack>True</Pack>
 			<PackagePath>\</PackagePath>
 		</None>
-		<None Include="..\..\README.md">
+		<!-- Pack THIS package's own README (it documents the identity seed), not the repo-root one. -->
+		<None Include="README.md">
 			<Pack>True</Pack>
 			<PackagePath>\</PackagePath>
 		</None>

--- a/src/MicroPlumberd.Service.Identity/MicroPlumberd.Services.Identity.csproj
+++ b/src/MicroPlumberd.Service.Identity/MicroPlumberd.Services.Identity.csproj
@@ -32,6 +32,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="MicroPlumberd.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\MicroPlumberd.Services\MicroPlumberd.Services.csproj" />
     <ProjectReference Include="..\MicroPlumberd.SourceGenerators\MicroPlumberd.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\MicroPlumberd\MicroPlumberd.csproj" />

--- a/src/MicroPlumberd.Service.Identity/README.md
+++ b/src/MicroPlumberd.Service.Identity/README.md
@@ -76,6 +76,26 @@ services.Configure<HostOptions>(o =>
     o.BackgroundServiceExceptionBehavior = BackgroundServiceExceptionBehavior.Ignore);
 ```
 
+## Non-web hosts must add data protection
+
+`AddPlumberdIdentity` calls `AddDefaultTokenProviders()`, which registers `DataProtectorTokenProvider<User>`. The
+`UserManager<TUser>` constructor resolves every provider in `Options.Tokens.ProviderMap`, so **`UserManager<User>`
+cannot be constructed without an `IDataProtectionProvider`**. A web host gets one from `WebApplicationBuilder`; a
+generic host (worker service, test host, `Host.CreateDefaultBuilder()`) does not, and the seed fails every attempt
+with:
+
+```
+Unable to resolve service for type 'Microsoft.AspNetCore.DataProtection.IDataProtectionProvider'
+while attempting to activate 'Microsoft.AspNetCore.Identity.DataProtectorTokenProvider`1[...User]'
+```
+
+The library does not register it for you — neither does ASP.NET Core's own `AddIdentity`/`AddIdentityCore`. In a
+non-web host, add it yourself:
+
+```csharp
+services.AddDataProtection();   // plus a key-persistence choice if the host is not ephemeral
+```
+
 ## Compatibility
 
 `AddIdentityInitializer(o => …)` and `IdentityInitializerOptions` keep their names and meaning. The call is now an

--- a/src/MicroPlumberd.Service.Identity/README.md
+++ b/src/MicroPlumberd.Service.Identity/README.md
@@ -1,3 +1,91 @@
+# Seeding
+
+`AddIdentitySeed` declares the identity state that must exist after start-up. The library converges the store to
+that declaration; it knows no role name and no user name of its own.
+
+```csharp
+services.AddPlumberd(settings);
+services.AddPlumberdIdentity();
+
+services.AddIdentitySeed(seed => seed
+    .Role("Administrator")
+    .Role("Accountant")
+    .User("admin@localhost", u => u.WithUserName("admin").WithPassword(pwd).InRoles("Administrator"))
+    .User("audit@example.com", u => u.InRoles("Auditor"))   // no password => external-login-only account
+    .Then(async (ctx, ct) => await ctx.EnsureRoleAsync("Reporting", ct))
+    .WaitUpTo(TimeSpan.FromSeconds(30)));
+```
+
+`AddIdentitySeed` may be called more than once; declarations accumulate in registration order and the hosted
+runner (`IdentityInitializerService`) is registered exactly once. The last `WaitUpTo` wins.
+
+## Ensure semantics
+
+Everything is **idempotent and additive**.
+
+| Declaration | What the seed guarantees | What it never does |
+|---|---|---|
+| `Role(n)` | The role exists after the seed converged. | Rename it, delete it, or touch a role that is not declared. |
+| `User(e)` | The user exists with `EmailConfirmed = true` and is a member of the declared roles. A role named in `InRoles` that was not declared with `Role` is ensured before the membership is assigned. | Modify an existing user: no password reset, no role removal, no user-name change. |
+
+Consequences worth stating:
+
+- A role dropped from the declaration is **left alone** — the seed is additive, it does not converge downwards.
+- A seeded user deleted by an operator is **recreated** on the next boot. To take an account out of service, lock it
+  or change its password; do not delete it.
+- Uniqueness is enforced by the read models, not by the store. Two **different hosts** seeding the same empty store
+  at the same instant can each create a role of the same name. Within one host — restarts, retries, concurrent
+  attempts — the ensure steps are idempotent.
+
+## Readiness, not time
+
+The seed starts when the read models it consults (`RolesModel`, `UsersModel`, `UserAuthorizationModel`) report
+`ICaughtUpHandler.CaughtUp()` — not after a `Task.Delay`. Each write then waits until **its own write is visible**
+in the read model the next step reads (`RoleManager.CreateAsync` appends an event; `AddToRoleAsync` reads the role
+back out of `RolesModel`, and a read taken before the fold is what used to throw
+`Role 'X' does not exist`).
+
+Both waits are bounded by one per-attempt bound, `WaitUpTo` (default 30 s). Expiry fails the **attempt**, never the
+host: the attempt logs at `Error`, and the runner retries with backoff `1, 2, 5, 10, 20, 30, 30…` seconds until it
+converges or the host stops. `TimeProvider` is resolved from DI when registered, so tests can compress the backoff.
+
+## Observing it
+
+`IdentityInitializerService.State` is an `IdentitySeedState(bool Ready, string Description, int Attempts, string? LastError)`
+snapshot, and `IdentityInitializerService.Completed` is a `Task` that completes when the seed converged.
+
+```csharp
+services.AddHealthChecks().AddIdentitySeedHealthCheck();   // entry "identity", untagged
+```
+
+The health check is **opt-in**: a patch upgrade must not silently add a `/health` entry to every consumer. It reads
+`State` live — Unhealthy naming the current step or the last error until the seed converged, Healthy afterwards.
+
+## `HostOptions.BackgroundServiceExceptionBehavior` — state it
+
+The .NET default is `BackgroundServiceExceptionBehavior.StopHost`: one background service that throws out of
+`ExecuteAsync` takes the whole host down. In a container that is a restart loop, and `/health` stays green right up
+to the moment the process exits.
+
+`IdentityInitializerService` never lets an exception escape `ExecuteAsync`, so it cannot trigger that on its own —
+but the option is host-wide and a library cannot set it on a consumer's behalf. **Set it explicitly, whichever way
+you want it**, so it is a stated choice and not an accident:
+
+```csharp
+services.Configure<HostOptions>(o =>
+    o.BackgroundServiceExceptionBehavior = BackgroundServiceExceptionBehavior.Ignore);
+```
+
+## Compatibility
+
+`AddIdentityInitializer(o => …)` and `IdentityInitializerOptions` keep their names and meaning. The call is now an
+adapter over the seed: `Role(AdminRoleName)`,
+`User(AdminEmail, WithUserName(AdminUserName), WithPassword(AdminPassword), InRoles(AdminRoleName))`,
+`WaitUpTo(ProjectionWaitTime)`. `SeedAdminUser = false` contributes nothing, so the seed is ready immediately.
+`ProjectionWaitTime` is no longer a delay — it is the per-attempt readiness bound.
+
+---
+
 Specifications for Integrating ASP.NET Core Identity with MicroPlumberd and EventStore
 Introduction
 This document outlines the specifications for integrating ASP.NET Core Identity with MicroPlumberd and EventStore in an ASP.NET Core application. The integration uses event sourcing (ES) and Command Query Responsibility Segregation (CQRS) to manage user and role data, providing scalability, auditability, and consistency. Designed with a Blazor application in mind, the solution is adaptable to any ASP.NET Core app. It supports all ASP.NET Core Identity features�user management, roles, claims, external logins, and two-factor authentication�while adhering to domain-driven design (DDD) principles.

--- a/src/MicroPlumberd.Service.Identity/README.md
+++ b/src/MicroPlumberd.Service.Identity/README.md
@@ -33,9 +33,15 @@ Consequences worth stating:
 - A role dropped from the declaration is **left alone** — the seed is additive, it does not converge downwards.
 - A seeded user deleted by an operator is **recreated** on the next boot. To take an account out of service, lock it
   or change its password; do not delete it.
+- Likewise a declared user whose e-mail an operator changed: the declared address is ensured as a **new account**.
+  The declaration is keyed by e-mail, so changing it away from the declared value reads as "the declared user is
+  missing".
 - Uniqueness is enforced by the read models, not by the store. Two **different hosts** seeding the same empty store
   at the same instant can each create a role of the same name. Within one host — restarts, retries, concurrent
   attempts — the ensure steps are idempotent.
+- The identity stores (`UserStore.AddToRoleAsync` / `RemoveFromRoleAsync` / `IsInRoleAsync`) assume the default
+  upper-invariant `ILookupNormalizer`. A custom normalizer is **unsupported end-to-end** — the seed's own keys are
+  normalizer-correct (`RoleManager.NormalizeKey`, `UserManager.NormalizeEmail`), but the stores are not.
 
 ## Readiness, not time
 

--- a/src/MicroPlumberd.Service.Identity/ReadModels/RolesModel.cs
+++ b/src/MicroPlumberd.Service.Identity/ReadModels/RolesModel.cs
@@ -14,8 +14,26 @@ namespace MicroPlumberd.Services.Identity.ReadModels
     /// </summary>
     [EventHandler]
     [OutputStream("RolesModel_v1")]
-    public partial class RolesModel
+    public partial class RolesModel : ICaughtUpHandler
     {
+
+        // Readiness (feature-001 design.md §2): the seed runner waits for this before its first read.
+        private readonly TaskCompletionSource _live = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        /// <summary>
+        /// Completes once the subscription feeding this read model has replayed history and gone live
+        /// (<see cref="ICaughtUpHandler.CaughtUp"/>). Completes once and stays completed.
+        /// </summary>
+        public Task Live => _live.Task;
+
+        /// <summary>
+        /// Called by the subscription runner on the history-to-live boundary; completes <see cref="Live"/>.
+        /// </summary>
+        public Task CaughtUp()
+        {
+            _live.TrySetResult();
+            return Task.CompletedTask;
+        }
         // Primary collection - clustered index
         private readonly ConcurrentDictionary<RoleIdentifier, Role> _rolesById = new();
 

--- a/src/MicroPlumberd.Service.Identity/ReadModels/UserAuthorizationModel.cs
+++ b/src/MicroPlumberd.Service.Identity/ReadModels/UserAuthorizationModel.cs
@@ -11,8 +11,26 @@ using System.Security.Claims;
 /// </summary>
 [EventHandler]
 [OutputStream("UserAuthorizationModel_v1")]
-public partial class UserAuthorizationModel
+public partial class UserAuthorizationModel : ICaughtUpHandler
 {
+
+    // Readiness (feature-001 design.md §2): the seed runner waits for this before its first read.
+    private readonly TaskCompletionSource _live = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    /// <summary>
+    /// Completes once the subscription feeding this read model has replayed history and gone live
+    /// (<see cref="ICaughtUpHandler.CaughtUp"/>). Completes once and stays completed.
+    /// </summary>
+    public Task Live => _live.Task;
+
+    /// <summary>
+    /// Called by the subscription runner on the history-to-live boundary; completes <see cref="Live"/>.
+    /// </summary>
+    public Task CaughtUp()
+    {
+        _live.TrySetResult();
+        return Task.CompletedTask;
+    }
     // Primary user authorization data store
     private readonly ConcurrentDictionary<UserIdentifier, UserAuthData> _userAuthData = new();
 

--- a/src/MicroPlumberd.Service.Identity/ReadModels/UsersModel.cs
+++ b/src/MicroPlumberd.Service.Identity/ReadModels/UsersModel.cs
@@ -13,8 +13,26 @@ namespace MicroPlumberd.Services.Identity.ReadModels
     /// </summary>
     [EventHandler]
     [OutputStream("UsersModel_v1")]
-    public partial class UsersModel
+    public partial class UsersModel : ICaughtUpHandler
     {
+
+        // Readiness (feature-001 design.md §2): the seed runner waits for this before its first read.
+        private readonly TaskCompletionSource _live = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        /// <summary>
+        /// Completes once the subscription feeding this read model has replayed history and gone live
+        /// (<see cref="ICaughtUpHandler.CaughtUp"/>). Completes once and stays completed.
+        /// </summary>
+        public Task Live => _live.Task;
+
+        /// <summary>
+        /// Called by the subscription runner on the history-to-live boundary; completes <see cref="Live"/>.
+        /// </summary>
+        public Task CaughtUp()
+        {
+            _live.TrySetResult();
+            return Task.CompletedTask;
+        }
         // Primary collection - clustered index
         private readonly ConcurrentDictionary<UserIdentifier, User> _usersById = new();
 

--- a/src/MicroPlumberd.Service.Identity/RoleStore.cs
+++ b/src/MicroPlumberd.Service.Identity/RoleStore.cs
@@ -86,6 +86,7 @@ public class RoleStore :
                 {
                     return IdentityResult.Failed(new IdentityError
                     {
+                        Code = "DuplicateRoleName",
                         Description = $"Role with name '{role.Name}' already exists"
                     });
                 }

--- a/src/MicroPlumberd.Tests/Integration/Identity/AdminSeedingTests.cs
+++ b/src/MicroPlumberd.Tests/Integration/Identity/AdminSeedingTests.cs
@@ -37,7 +37,7 @@ public class AdminSeedingTests : IClassFixture<EventStoreServer>, IAsyncLifetime
                 services.AddPlumberdIdentity();
                 // pre-existing red on master: UserManager<User> resolves DataProtectorTokenProvider
                 // (AddDefaultTokenProviders) which needs IDataProtectionProvider; a generic Host has none
-                // — see epic-083 feature-001 §4.1
+                // — see epic-083 feature-001 status.md (AdminSeedingTests pre-existing red)
                 services.AddDataProtection();
 
                 if (configureInitializer != null)

--- a/src/MicroPlumberd.Tests/Integration/Identity/AdminSeedingTests.cs
+++ b/src/MicroPlumberd.Tests/Integration/Identity/AdminSeedingTests.cs
@@ -35,6 +35,10 @@ public class AdminSeedingTests : IClassFixture<EventStoreServer>, IAsyncLifetime
             {
                 services.AddPlumberd(_eventStore.GetEventStoreSettings());
                 services.AddPlumberdIdentity();
+                // pre-existing red on master: UserManager<User> resolves DataProtectorTokenProvider
+                // (AddDefaultTokenProviders) which needs IDataProtectionProvider; a generic Host has none
+                // — see epic-083 feature-001 §4.1
+                services.AddDataProtection();
 
                 if (configureInitializer != null)
                 {

--- a/src/MicroPlumberd.Tests/Integration/Identity/IdentitySeedTests.cs
+++ b/src/MicroPlumberd.Tests/Integration/Identity/IdentitySeedTests.cs
@@ -1,0 +1,508 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using FluentAssertions;
+using MicroPlumberd.Services;
+using MicroPlumberd.Services.Identity;
+using MicroPlumberd.Services.Identity.ReadModels;
+using MicroPlumberd.Testing;
+using MicroPlumberd.Tests.Utils;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Xunit.Abstractions;
+
+namespace MicroPlumberd.Tests.Integration.Identity;
+
+/// <summary>
+/// AT-01…AT-08 of epic-083 feature-001 (acceptance-tests.md).
+/// Every host below leaves <see cref="HostOptions.BackgroundServiceExceptionBehavior"/> at the .NET default
+/// (<see cref="BackgroundServiceExceptionBehavior.StopHost"/>) on purpose: the tests prove the runner's catch,
+/// not the option.
+/// </summary>
+[TestCategory("Integration")]
+public class IdentitySeedTests : IClassFixture<EventStoreServer>, IAsyncLifetime
+{
+    /// <summary>Hard cap for every wait in this file. Never a blind Task.Delay.</summary>
+    private static readonly TimeSpan Cap = TimeSpan.FromSeconds(90);
+
+    private readonly EventStoreServer _eventStore;
+    private readonly ITestOutputHelper _output;
+
+    public IdentitySeedTests(EventStoreServer eventStore, ITestOutputHelper output)
+    {
+        _eventStore = eventStore;
+        _output = output;
+    }
+
+    /// <summary>Restarting the in-memory container wipes it, so every test starts from a fresh store.</summary>
+    public async Task InitializeAsync() => await _eventStore.StartInDocker(inMemory: true);
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    #region AT-01
+
+    [Fact]
+    public async Task AT01_FreshStore_ConvergesOnTheFirstAttempt()
+    {
+        var logs = NewLogs();
+        using var host = CreateHost(logs, s => s.AddIdentitySeed(seed => seed
+            .Role("Administrator")
+            .Role("Accountant")
+            .User("admin@localhost", u => u.WithUserName("admin").WithPassword("Admin123!").InRoles("Administrator"))));
+
+        await host.StartAsync();
+        await Seed(host).Completed.WaitAsync(Cap);
+
+        var roles = host.Services.GetRequiredService<RolesModel>();
+        var users = host.Services.GetRequiredService<UsersModel>();
+        var userAuth = host.Services.GetRequiredService<UserAuthorizationModel>();
+
+        roles.GetAllRoles().Select(r => r.Name).Should().BeEquivalentTo("Administrator", "Accountant");
+
+        var all = users.GetAllUsers();
+        all.Should().HaveCount(1);
+        all[0].Email.Should().Be("admin@localhost");
+        all[0].UserName.Should().Be("admin");
+        all[0].EmailConfirmed.Should().BeTrue();
+
+        userAuth.IsInRole(UserIdentifier.Parse(all[0].Id, null), "ADMINISTRATOR").Should().BeTrue();
+
+        using (var scope = host.Services.CreateScope())
+        {
+            var userManager = scope.ServiceProvider.GetRequiredService<UserManager<User>>();
+            var user = await userManager.FindByEmailAsync("admin@localhost");
+            user.Should().NotBeNull();
+            (await userManager.IsInRoleAsync(user!, "Administrator")).Should().BeTrue();
+        }
+
+        Seed(host).State.Ready.Should().BeTrue();
+        Seed(host).State.Attempts.Should().Be(1);
+        (await HealthOf(host)).Status.Should().Be(HealthStatus.Healthy);
+
+        logs.Errors.Should().BeEmpty("a converging seed writes nothing at Error level");
+
+        await host.StopAsync();
+    }
+
+    #endregion
+
+    #region AT-02
+
+    [Fact]
+    public async Task AT02_RestartIsIdempotentAndNeverModifiesAnExistingUser()
+    {
+        // The store from AT-01, then an operator changes the password.
+        using (var first = CreateHost(NewLogs(), s => s.AddIdentitySeed(seed => AdminDeclaration(seed))))
+        {
+            await first.StartAsync();
+            await Seed(first).Completed.WaitAsync(Cap);
+
+            using var scope = first.Services.CreateScope();
+            var userManager = scope.ServiceProvider.GetRequiredService<UserManager<User>>();
+            var user = await userManager.FindByEmailAsync("admin@localhost");
+            user.Should().NotBeNull();
+
+            var changed = await userManager.ChangePasswordAsync(user!, "Admin123!", "Changed456!");
+            changed.Succeeded.Should().BeTrue(
+                "the operator's password change must land: {0}", string.Join(", ", changed.Errors.Select(e => e.Description)));
+
+            await Until(() => userManager.CheckPasswordAsync(user!, "Changed456!"), "the new password to be folded");
+
+            await first.StopAsync();
+        }
+
+        // The same declaration, second host, same store.
+        var logs = NewLogs();
+        using var second = CreateHost(logs, s => s.AddIdentitySeed(seed => AdminDeclaration(seed)));
+        await second.StartAsync();
+        await Seed(second).Completed.WaitAsync(Cap);
+
+        var roles = second.Services.GetRequiredService<RolesModel>();
+        var users = second.Services.GetRequiredService<UsersModel>();
+
+        roles.GetAllRoles().Where(r => r.Name == "Administrator").Should().HaveCount(1);
+        roles.GetAllRoles().Where(r => r.Name == "Accountant").Should().HaveCount(1);
+        users.GetAllUsers().Should().HaveCount(1);
+
+        using (var scope = second.Services.CreateScope())
+        {
+            var userManager = scope.ServiceProvider.GetRequiredService<UserManager<User>>();
+            var user = await userManager.FindByEmailAsync("admin@localhost");
+            user.Should().NotBeNull();
+            (await userManager.CheckPasswordAsync(user!, "Changed456!"))
+                .Should().BeTrue("the seed must not reset the password of an existing user");
+            (await userManager.CheckPasswordAsync(user!, "Admin123!"))
+                .Should().BeFalse("the declared password must not have been re-applied");
+        }
+
+        Seed(second).State.Attempts.Should().Be(1);
+        logs.Errors.Should().BeEmpty();
+
+        await second.StopAsync();
+    }
+
+    #endregion
+
+    #region AT-03
+
+    [Fact]
+    public async Task AT03_ARoleDroppedFromTheDeclarationIsLeftAlone()
+    {
+        await SeedAdminHost();
+
+        var logs = NewLogs();
+        using var host = CreateHost(logs, s => s.AddIdentitySeed(seed => seed.Role("Administrator")));
+        await host.StartAsync();
+        await Seed(host).Completed.WaitAsync(Cap);
+
+        var roles = host.Services.GetRequiredService<RolesModel>();
+        roles.GetAllRoles().Select(r => r.Name).Should().Contain("Accountant",
+            "the seed is additive: dropping a role from the declaration never deletes it");
+        roles.GetAllRoles().Select(r => r.Name).Should().Contain("Administrator");
+
+        await host.StopAsync();
+    }
+
+    #endregion
+
+    #region AT-04
+
+    [Fact]
+    public async Task AT04_AUserWithoutAPasswordIsAnExternalLoginOnlyAccount()
+    {
+        var logs = NewLogs();
+        using var host = CreateHost(logs, s => s.AddIdentitySeed(seed => seed
+            .Role("Auditor")
+            .User("audit@example.com", u => u.InRoles("Auditor"))));
+
+        await host.StartAsync();
+        await Seed(host).Completed.WaitAsync(Cap);
+
+        using var scope = host.Services.CreateScope();
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<User>>();
+        var user = await userManager.FindByEmailAsync("audit@example.com");
+
+        user.Should().NotBeNull();
+        user!.UserName.Should().Be("audit@example.com", "the user name defaults to the e-mail");
+        (await userManager.IsInRoleAsync(user, "Auditor")).Should().BeTrue();
+        (await userManager.HasPasswordAsync(user)).Should().BeFalse();
+
+        logs.Errors.Should().BeEmpty();
+
+        await host.StopAsync();
+    }
+
+    #endregion
+
+    #region AT-05
+
+    [Fact]
+    public async Task AT05_AFailingStepNeverStopsTheHost_HealthNamesIt_AndTheRetrySucceeds()
+    {
+        var invocations = 0;
+        var logs = NewLogs();
+
+        // Compressed, not instantaneous: the backoff windows (500 ms, 1 s) stay long enough to sample health
+        // deterministically, while the whole test still costs well under two seconds of waiting.
+        using var host = CreateHost(logs, s => s.AddIdentitySeed(seed => seed
+            .Role("Administrator")
+            .Then((_, _) =>
+            {
+                if (Interlocked.Increment(ref invocations) <= 2)
+                    throw new InvalidOperationException("planted");
+                return Task.CompletedTask;
+            })
+            .WaitUpTo(TimeSpan.FromMinutes(2))), new CompressedTimeProvider(2));
+
+        using var samplerStop = new CancellationTokenSource();
+        var sawPlantedUnhealthy = 0;
+        var sampler = Task.Run(async () =>
+        {
+            while (!samplerStop.IsCancellationRequested)
+            {
+                var entry = await HealthOf(host);
+                if (entry.Status == HealthStatus.Unhealthy && (entry.Description?.Contains("planted") ?? false))
+                    Interlocked.Exchange(ref sawPlantedUnhealthy, 1);
+                try { await Task.Delay(10, samplerStop.Token); } catch (OperationCanceledException) { }
+            }
+        });
+
+        await host.StartAsync();
+        await Seed(host).Completed.WaitAsync(Cap);
+        await samplerStop.CancelAsync();
+        await sampler;
+
+        // Positive controls first: the failure really happened and was really reported.
+        logs.Errors.Any(l => l.Message.Contains("Identity seed attempt") && l.Message.Contains("planted"))
+            .Should().BeTrue("a failed attempt logs at Error naming the attempt and the cause");
+        logs.Errors.Any(l => l.Exception is InvalidOperationException)
+            .Should().BeTrue("the Error line carries the original exception");
+        sawPlantedUnhealthy.Should().Be(1, "health entry 'identity' must be Unhealthy naming 'planted' while the step is failing");
+
+        // The host is still running.
+        var lifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
+        lifetime.ApplicationStopping.IsCancellationRequested.Should().BeFalse();
+        host.Services.GetRequiredService<RolesModel>().Should().NotBeNull();
+
+        invocations.Should().Be(3);
+        Seed(host).State.Ready.Should().BeTrue();
+        Seed(host).State.Attempts.Should().Be(3);
+        (await HealthOf(host)).Status.Should().Be(HealthStatus.Healthy);
+
+        host.Services.GetRequiredService<RolesModel>().GetAllRoles()
+            .Where(r => r.Name == "Administrator").Should().HaveCount(1,
+                "the retried attempts re-run the whole plan and every step is idempotent");
+
+        await host.StopAsync();
+    }
+
+    #endregion
+
+    #region AT-06
+
+    [Fact]
+    public async Task AT06_ACompressedReadinessBoundSummonsTheFailureAndTheSameHostCuresItself()
+    {
+        await SeedAdminHost();
+
+        var logs = NewLogs();
+        using var host = CreateHost(logs, s => s.AddIdentitySeed(seed => AdminDeclaration(seed).WaitUpTo(TimeSpan.FromMilliseconds(1))),
+            new CompressedTimeProvider(10));
+
+        await host.StartAsync();
+        await Seed(host).Completed.WaitAsync(Cap);
+
+        logs.Errors.Any(l => l.Exception is TimeoutException &&
+                             (l.Exception.Message.Contains("identity read models") ||
+                              l.Exception.Message.Contains("visible")))
+            .Should().BeTrue("a 1 ms per-attempt bound cannot cover a replay, so at least one attempt must time out");
+
+        host.Services.GetRequiredService<IHostApplicationLifetime>()
+            .ApplicationStopping.IsCancellationRequested.Should().BeFalse();
+
+        Seed(host).State.Ready.Should().BeTrue();
+        Seed(host).State.Attempts.Should().BeGreaterThan(1);
+
+        var roles = host.Services.GetRequiredService<RolesModel>();
+        roles.GetAllRoles().Where(r => r.Name == "Administrator").Should().HaveCount(1);
+        roles.GetAllRoles().Where(r => r.Name == "Accountant").Should().HaveCount(1);
+        host.Services.GetRequiredService<UsersModel>().GetAllUsers().Should().HaveCount(1,
+            "the failed attempts wrote nothing, so they cannot have produced duplicates");
+
+        await host.StopAsync();
+    }
+
+    #endregion
+
+    #region AT-07
+
+    [Fact]
+    public async Task AT07_HealthNamesTheStepInProgress()
+    {
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var logs = NewLogs();
+
+        using var host = CreateHost(logs, s => s.AddIdentitySeed(seed => seed
+            .Role("Administrator")
+            .Then(async (_, ct) => await gate.Task.WaitAsync(ct))));
+
+        await host.StartAsync();
+
+        await Until(async () =>
+        {
+            var e = await HealthOf(host);
+            return e.Status == HealthStatus.Unhealthy && (e.Description?.Contains("custom step #2") ?? false);
+        }, "health 'identity' to be Unhealthy naming the custom step in progress");
+
+        Seed(host).State.Ready.Should().BeFalse();
+
+        gate.SetResult();
+
+        await Seed(host).Completed.WaitAsync(Cap);
+        (await HealthOf(host)).Status.Should().Be(HealthStatus.Healthy);
+        Seed(host).State.Ready.Should().BeTrue();
+
+        await host.StopAsync();
+    }
+
+    #endregion
+
+    #region AT-08
+
+    [Fact]
+    public async Task AT08_TheLegacyAddIdentityInitializerIsAnAdapterOverTheSeed()
+    {
+        // SeedAdminUser = false => empty seed => Ready immediately, nothing created.
+        using (var disabled = CreateHost(NewLogs(), s => s.AddIdentityInitializer(o =>
+               {
+                   o.SeedAdminUser = false;
+                   o.ProjectionWaitTime = TimeSpan.FromSeconds(5);
+               })))
+        {
+            await disabled.StartAsync();
+            await Seed(disabled).Completed.WaitAsync(TimeSpan.FromSeconds(10));
+
+            Seed(disabled).State.Ready.Should().BeTrue();
+            Seed(disabled).State.Attempts.Should().Be(0, "an empty seed never starts an attempt");
+            Seed(disabled).State.Description.Should().Be("nothing declared");
+            (await HealthOf(disabled)).Status.Should().Be(HealthStatus.Healthy);
+
+            disabled.Services.GetRequiredService<RolesModel>().GetAllRoles().Should().BeEmpty();
+            disabled.Services.GetRequiredService<UsersModel>().GetAllUsers().Should().BeEmpty();
+
+            await disabled.StopAsync();
+        }
+
+        var logs = NewLogs();
+        using var host = CreateHost(logs, s => s.AddIdentityInitializer(o =>
+        {
+            o.AdminEmail = "root@x";
+            o.AdminUserName = "root";
+            o.AdminPassword = "Root123!";
+            o.AdminRoleName = "Owner";
+            o.ProjectionWaitTime = TimeSpan.FromSeconds(5);
+        }));
+
+        await host.StartAsync();
+        await Seed(host).Completed.WaitAsync(Cap);
+
+        host.Services.GetRequiredService<RolesModel>().GetAllRoles()
+            .Select(r => r.Name).Should().BeEquivalentTo("Owner");
+
+        using (var scope = host.Services.CreateScope())
+        {
+            var userManager = scope.ServiceProvider.GetRequiredService<UserManager<User>>();
+            var user = await userManager.FindByEmailAsync("root@x");
+            user.Should().NotBeNull();
+            user!.UserName.Should().Be("root");
+            (await userManager.IsInRoleAsync(user, "Owner")).Should().BeTrue();
+            (await userManager.CheckPasswordAsync(user, "Root123!")).Should().BeTrue();
+        }
+
+        Seed(host).State.Attempts.Should().Be(1);
+        logs.Errors.Should().BeEmpty();
+
+        await host.StopAsync();
+    }
+
+    #endregion
+
+    #region Harness
+
+    private static IdentitySeedBuilder AdminDeclaration(IdentitySeedBuilder seed) => seed
+        .Role("Administrator")
+        .Role("Accountant")
+        .User("admin@localhost", u => u.WithUserName("admin").WithPassword("Admin123!").InRoles("Administrator"));
+
+    /// <summary>Runs one host that seeds the AT-01 state, then stops it. Leaves the store populated.</summary>
+    private async Task SeedAdminHost()
+    {
+        using var host = CreateHost(NewLogs(), s => s.AddIdentitySeed(seed => AdminDeclaration(seed)));
+        await host.StartAsync();
+        await Seed(host).Completed.WaitAsync(Cap);
+        await host.StopAsync();
+    }
+
+    private static IdentityInitializerService Seed(IHost host) =>
+        host.Services.GetRequiredService<IdentityInitializerService>();
+
+    private static async Task<HealthReportEntry> HealthOf(IHost host)
+    {
+        var report = await host.Services.GetRequiredService<HealthCheckService>().CheckHealthAsync();
+        report.Entries.Should().ContainKey("identity");
+        return report.Entries["identity"];
+    }
+
+    private IHost CreateHost(CapturedLogs logs, Action<IServiceCollection> configure, TimeProvider? time = null) =>
+        Host.CreateDefaultBuilder()
+            .ConfigureLogging(l =>
+            {
+                l.ClearProviders();
+                l.AddProvider(new CapturingLoggerProvider(logs));
+                l.SetMinimumLevel(LogLevel.Debug);
+            })
+            .ConfigureServices((_, services) =>
+            {
+                services.AddPlumberd(_eventStore.GetEventStoreSettings());
+                services.AddPlumberdIdentity();
+                // AddPlumberdIdentity -> AddDefaultTokenProviders registers DataProtectorTokenProvider, and
+                // UserManager's constructor resolves every provider in Options.Tokens.ProviderMap. A web host gets
+                // data protection from WebApplicationBuilder; a plain Host.CreateDefaultBuilder does not, so the
+                // harness supplies it. Without it UserManager<User> cannot be constructed at all.
+                services.AddDataProtection();
+                if (time is not null) services.AddSingleton(time);
+                services.AddHealthChecks().AddIdentitySeedHealthCheck();
+                configure(services);
+                // HostOptions deliberately left at the .NET default (StopHost).
+            })
+            .Build();
+
+    private CapturedLogs NewLogs() => new(_output);
+
+    private static async Task Until(Func<Task<bool>> condition, string what)
+    {
+        var sw = Stopwatch.StartNew();
+        while (!await condition())
+        {
+            if (sw.Elapsed > Cap)
+                throw new TimeoutException($"Timed out after {Cap} waiting for {what}.");
+            await Task.Delay(25);
+        }
+    }
+
+    /// <summary>
+    /// A <see cref="TimeProvider"/> whose timers fire <paramref name="factor"/> times sooner than asked, so a test
+    /// can compress the retry backoff and the per-attempt bound without touching the wall clock.
+    /// Everything the runner waits on (<c>Task.Delay</c>, <c>Task.WaitAsync</c>, the deadline
+    /// <see cref="CancellationTokenSource"/>) goes through <see cref="TimeProvider.CreateTimer"/>, so all of it
+    /// compresses uniformly.
+    /// </summary>
+    private sealed class CompressedTimeProvider(int factor) : TimeProvider
+    {
+        public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
+            => base.CreateTimer(callback, state, Scale(dueTime), Scale(period));
+
+        private TimeSpan Scale(TimeSpan t) =>
+            t < TimeSpan.Zero ? t : TimeSpan.FromTicks(t.Ticks / factor);
+    }
+
+    internal sealed record LogRecord(LogLevel Level, string Category, string Message, Exception? Exception);
+
+    /// <summary>Log sink of one host. <see cref="Errors"/> is the positive control several ATs assert on.</summary>
+    internal sealed class CapturedLogs(ITestOutputHelper output)
+    {
+        private readonly ConcurrentQueue<LogRecord> _all = new();
+
+        public void Add(LogRecord r)
+        {
+            _all.Enqueue(r);
+            try { output.WriteLine($"[{r.Level}] {r.Category}: {r.Message}{(r.Exception is null ? "" : " <- " + r.Exception.GetType().Name + ": " + r.Exception.Message)}"); }
+            catch (InvalidOperationException) { /* the test already finished */ }
+        }
+
+        /// <summary>Error (and worse) written by the seed itself.</summary>
+        public IReadOnlyList<LogRecord> Errors => _all
+            .Where(r => r.Level >= LogLevel.Error && r.Category.Contains(nameof(IdentityInitializerService)))
+            .ToList();
+    }
+
+    private sealed class CapturingLoggerProvider(CapturedLogs logs) : ILoggerProvider
+    {
+        public ILogger CreateLogger(string categoryName) => new CapturingLogger(categoryName, logs);
+        public void Dispose() { }
+
+        private sealed class CapturingLogger(string category, CapturedLogs logs) : ILogger
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+                Func<TState, Exception?, string> formatter)
+                => logs.Add(new LogRecord(logLevel, category, formatter(state, exception), exception));
+        }
+    }
+
+    #endregion
+}

--- a/src/MicroPlumberd.Tests/Integration/Identity/IdentitySeedTests.cs
+++ b/src/MicroPlumberd.Tests/Integration/Identity/IdentitySeedTests.cs
@@ -143,6 +143,70 @@ public class IdentitySeedTests : IClassFixture<EventStoreServer>, IAsyncLifetime
         await second.StopAsync();
     }
 
+    [Fact]
+    public async Task AT02b_AnExistingUnconfirmedDeclaredUserIsConfirmedAndNothingElseIsTouched()
+    {
+        // Given: a user an operator created with a password, which the store persists UNCONFIRMED
+        // (UserStore.CreateAsync does not carry User.EmailConfirmed into UserProfileAggregate).
+        using (var first = CreateHost(NewLogs(), s => s.AddIdentitySeed(seed => seed.Role("Administrator"))))
+        {
+            await first.StartAsync();
+            await Seed(first).Completed.WaitAsync(Cap);
+
+            using var scope = first.Services.CreateScope();
+            var userManager = scope.ServiceProvider.GetRequiredService<UserManager<User>>();
+            var created = await userManager.CreateAsync(
+                new User { UserName = "operator", Email = "unconfirmed@example.com", EmailConfirmed = true },
+                "Original123!");
+            created.Succeeded.Should().BeTrue(
+                "the operator's user must land: {0}", string.Join(", ", created.Errors.Select(e => e.Description)));
+
+            await Until(async () => await userManager.FindByEmailAsync("unconfirmed@example.com") is not null,
+                "the operator's user to become visible");
+
+            // Positive control: the precondition this test exists for really holds.
+            var beforeSeed = await userManager.FindByEmailAsync("unconfirmed@example.com");
+            beforeSeed!.EmailConfirmed.Should().BeFalse(
+                "UserStore.CreateAsync leaves the profile unconfirmed - without that this test proves nothing");
+
+            await first.StopAsync();
+        }
+
+        // When: a host declares that same user.
+        var logs = NewLogs();
+        using var second = CreateHost(logs, s => s.AddIdentitySeed(seed => seed
+            .Role("Administrator")
+            .User("unconfirmed@example.com", u => u
+                .WithUserName("seeded")
+                .WithPassword("Seeded999!")
+                .InRoles("Administrator"))));
+
+        await second.StartAsync();
+        await Seed(second).Completed.WaitAsync(Cap);
+
+        second.Services.GetRequiredService<UsersModel>().GetAllUsers().Should().HaveCount(1);
+
+        using (var scope = second.Services.CreateScope())
+        {
+            var userManager = scope.ServiceProvider.GetRequiredService<UserManager<User>>();
+            var user = await userManager.FindByEmailAsync("unconfirmed@example.com");
+            user.Should().NotBeNull();
+
+            user!.EmailConfirmed.Should().BeTrue("the confirm-only flip false->true is part of the declared state");
+            (await userManager.IsInRoleAsync(user, "Administrator")).Should().BeTrue();
+
+            // ...and it is the ONLY write applied to an existing user.
+            user.UserName.Should().Be("operator", "the declared user name must not overwrite an existing one");
+            (await userManager.CheckPasswordAsync(user, "Original123!"))
+                .Should().BeTrue("the declared password must not be applied to an existing user");
+            (await userManager.CheckPasswordAsync(user, "Seeded999!")).Should().BeFalse();
+        }
+
+        logs.Errors.Should().BeEmpty();
+
+        await second.StopAsync();
+    }
+
     #endregion
 
     #region AT-03
@@ -208,11 +272,14 @@ public class IdentitySeedTests : IClassFixture<EventStoreServer>, IAsyncLifetime
         // deterministically, while the whole test still costs well under two seconds of waiting.
         using var host = CreateHost(logs, s => s.AddIdentitySeed(seed => seed
             .Role("Administrator")
-            .Then((_, _) =>
+            .Then(async (ctx, ct) =>
             {
                 if (Interlocked.Increment(ref invocations) <= 2)
                     throw new InvalidOperationException("planted");
-                return Task.CompletedTask;
+
+                // R6: the escape hatch works through the context, with the same read-your-write waits.
+                await ctx.EnsureRoleAsync("FromCustomStep", ct);
+                await ctx.EnsureUserAsync("custom@example.com", ct: ct);
             })
             .WaitUpTo(TimeSpan.FromMinutes(2))), new CompressedTimeProvider(2));
 
@@ -251,9 +318,21 @@ public class IdentitySeedTests : IClassFixture<EventStoreServer>, IAsyncLifetime
         Seed(host).State.Attempts.Should().Be(3);
         (await HealthOf(host)).Status.Should().Be(HealthStatus.Healthy);
 
-        host.Services.GetRequiredService<RolesModel>().GetAllRoles()
-            .Where(r => r.Name == "Administrator").Should().HaveCount(1,
-                "the retried attempts re-run the whole plan and every step is idempotent");
+        var rolesAfter = host.Services.GetRequiredService<RolesModel>().GetAllRoles();
+        rolesAfter.Where(r => r.Name == "Administrator").Should().HaveCount(1,
+            "the retried attempts re-run the whole plan and every step is idempotent");
+
+        // R6: what the custom step did through IIdentitySeedContext really landed.
+        rolesAfter.Where(r => r.Name == "FromCustomStep").Should().HaveCount(1);
+        using (var scope = host.Services.CreateScope())
+        {
+            var userManager = scope.ServiceProvider.GetRequiredService<UserManager<User>>();
+            var fromStep = await userManager.FindByEmailAsync("custom@example.com");
+            fromStep.Should().NotBeNull();
+            fromStep!.UserName.Should().Be("custom@example.com", "EnsureUserAsync defaults the user name to the e-mail");
+            fromStep.EmailConfirmed.Should().BeTrue();
+            (await userManager.HasPasswordAsync(fromStep)).Should().BeFalse();
+        }
 
         await host.StopAsync();
     }
@@ -294,6 +373,57 @@ public class IdentitySeedTests : IClassFixture<EventStoreServer>, IAsyncLifetime
         await host.StopAsync();
     }
 
+    [Fact]
+    public async Task AT06b_APostWriteVisibilityTimeoutIsRetriedWithoutCreatingDuplicates()
+    {
+        // A FRESH store plus a 1 ms per-attempt bound: once the read models are live, every attempt writes and
+        // then times out waiting for its own write to be projected back. That is the path that used to create a
+        // duplicate role/user on the next attempt (the stores dedupe only through the still-unfolded read model).
+        //
+        // The compression factor is load-bearing, not cosmetic. The duplicate only exists in the window between
+        // "the append returned" and "the projection delivered it back" (measured here: tens of milliseconds). At
+        // x10 the retry lands AFTER that window, the read model already shows the role, and the test passes even
+        // with the written-keys memory removed - i.e. it proves nothing. At x1000 the retry lands inside the
+        // window, so this test fails (two roles, two users) if the memory is taken away. Verified by mutation.
+        var logs = NewLogs();
+        using var host = CreateHost(logs, s => s.AddIdentitySeed(seed => seed
+            .Role("Administrator")
+            .User("admin@localhost", u => u.WithUserName("admin").WithPassword("Admin123!").InRoles("Administrator"))
+            .WaitUpTo(TimeSpan.FromMilliseconds(1))), new CompressedTimeProvider(1000));
+
+        await host.StartAsync();
+        await Seed(host).Completed.WaitAsync(Cap);
+
+        // Positive control: at least one attempt really failed AFTER a write, in a visibility wait - not only in
+        // the read-model wait that happens before anything is written.
+        logs.Errors.Any(l => l.Exception is TimeoutException && l.Exception.Message.Contains("to become visible"))
+            .Should().BeTrue("a 1 ms bound cannot cover an append being projected back, so a post-write wait must time out");
+
+        host.Services.GetRequiredService<IHostApplicationLifetime>()
+            .ApplicationStopping.IsCancellationRequested.Should().BeFalse();
+
+        Seed(host).State.Ready.Should().BeTrue();
+        Seed(host).State.Attempts.Should().BeGreaterThan(1);
+
+        var roles = host.Services.GetRequiredService<RolesModel>();
+        roles.GetAllRoles().Should().HaveCount(1, "the retried attempts must not create a second role");
+        roles.GetAllRoles().Single().Name.Should().Be("Administrator");
+
+        var users = host.Services.GetRequiredService<UsersModel>();
+        users.GetAllUsers().Should().HaveCount(1, "the retried attempts must not create a second user");
+        users.GetAllUsers().Single().EmailConfirmed.Should().BeTrue();
+
+        using (var scope = host.Services.CreateScope())
+        {
+            var userManager = scope.ServiceProvider.GetRequiredService<UserManager<User>>();
+            var user = await userManager.FindByEmailAsync("admin@localhost");
+            user.Should().NotBeNull();
+            (await userManager.IsInRoleAsync(user!, "Administrator")).Should().BeTrue();
+        }
+
+        await host.StopAsync();
+    }
+
     #endregion
 
     #region AT-07
@@ -313,7 +443,7 @@ public class IdentitySeedTests : IClassFixture<EventStoreServer>, IAsyncLifetime
         await Until(async () =>
         {
             var e = await HealthOf(host);
-            return e.Status == HealthStatus.Unhealthy && (e.Description?.Contains("custom step #2") ?? false);
+            return e.Status == HealthStatus.Unhealthy && (e.Description?.Contains("custom step #1") ?? false);
         }, "health 'identity' to be Unhealthy naming the custom step in progress");
 
         Seed(host).State.Ready.Should().BeFalse();

--- a/src/MicroPlumberd.Tests/Unit/Identity/IdentitySeedBuilderTests.cs
+++ b/src/MicroPlumberd.Tests/Unit/Identity/IdentitySeedBuilderTests.cs
@@ -35,7 +35,7 @@ public class IdentitySeedBuilderTests
             "role 'Administrator'",
             "user 'admin@localhost'",
             "role 'Accountant'",
-            "custom step #4");
+            "custom step #1");
     }
 
     [Fact]
@@ -48,6 +48,33 @@ public class IdentitySeedBuilderTests
         });
 
         plan.Build().Select(x => x.Label).Should().Equal("role 'First'", "role 'Second'");
+    }
+
+    [Fact]
+    public void Then_DefaultLabelCountsCustomStepsOnly()
+    {
+        var plan = PlanOf(s => s.AddIdentitySeed(seed => seed
+            .Role("A")
+            .Then((_, _) => Task.CompletedTask)
+            .Role("B")
+            .Then((_, _) => Task.CompletedTask)));
+
+        plan.Build().OfType<CustomStep>().Select(x => x.Label)
+            .Should().Equal("custom step #1", "custom step #2");
+    }
+
+    [Fact]
+    public void AddIdentityInitializer_CalledTwice_DoesNotDoubleThePlan()
+    {
+        var plan = PlanOf(s =>
+        {
+            s.AddIdentityInitializer(o => o.AdminRoleName = "Owner");
+            s.AddIdentityInitializer(o => o.AdminEmail = "root@x");
+        });
+
+        var steps = plan.Build();
+        steps.OfType<RoleStep>().Should().ContainSingle();
+        steps.OfType<UserStep>().Should().ContainSingle();
     }
 
     [Fact]

--- a/src/MicroPlumberd.Tests/Unit/Identity/IdentitySeedBuilderTests.cs
+++ b/src/MicroPlumberd.Tests/Unit/Identity/IdentitySeedBuilderTests.cs
@@ -1,0 +1,169 @@
+using FluentAssertions;
+using MicroPlumberd.Services.Identity;
+using MicroPlumberd.Tests.Utils;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MicroPlumberd.Tests.Unit.Identity;
+
+/// <summary>
+/// Plan construction for the identity seed (epic-083 feature-001, acceptance-tests.md "Non-scenario proofs"):
+/// declaration order, accumulation across calls, defaults, and the retry backoff sequence.
+/// </summary>
+[TestCategory("Unit")]
+public class IdentitySeedBuilderTests
+{
+    private static IdentitySeedPlan PlanOf(Action<IServiceCollection> configure)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        configure(services);
+        return services.BuildServiceProvider().GetRequiredService<IdentitySeedPlan>();
+    }
+
+    [Fact]
+    public void Build_PreservesDeclarationOrder()
+    {
+        var plan = PlanOf(s => s.AddIdentitySeed(seed => seed
+            .Role("Administrator")
+            .User("admin@localhost", u => u.WithUserName("admin").WithPassword("Admin123!").InRoles("Administrator"))
+            .Role("Accountant")
+            .Then((_, _) => Task.CompletedTask)));
+
+        var steps = plan.Build();
+
+        steps.Select(x => x.Label).Should().ContainInOrder(
+            "role 'Administrator'",
+            "user 'admin@localhost'",
+            "role 'Accountant'",
+            "custom step #4");
+    }
+
+    [Fact]
+    public void Build_AccumulatesAcrossSeveralAddIdentitySeedCalls()
+    {
+        var plan = PlanOf(s =>
+        {
+            s.AddIdentitySeed(seed => seed.Role("First"));
+            s.AddIdentitySeed(seed => seed.Role("Second"));
+        });
+
+        plan.Build().Select(x => x.Label).Should().Equal("role 'First'", "role 'Second'");
+    }
+
+    [Fact]
+    public void Build_RegistersTheHostedRunnerExactlyOnceHoweverManyCalls()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddIdentitySeed(seed => seed.Role("First"));
+        services.AddIdentitySeed(seed => seed.Role("Second"));
+        services.AddIdentityInitializer(o => o.AdminRoleName = "Third");
+
+        services.Count(d => d.ServiceType == typeof(Microsoft.Extensions.Hosting.IHostedService))
+            .Should().Be(1);
+    }
+
+    [Fact]
+    public void WaitUpTo_DefaultsTo30Seconds()
+    {
+        var plan = PlanOf(s => s.AddIdentitySeed(seed => seed.Role("Administrator")));
+        plan.Build();
+
+        plan.WaitUpTo.Should().Be(TimeSpan.FromSeconds(30));
+        IdentitySeedBuilder.DefaultWaitUpTo.Should().Be(TimeSpan.FromSeconds(30));
+    }
+
+    [Fact]
+    public void WaitUpTo_LastCallWins()
+    {
+        var plan = PlanOf(s =>
+        {
+            s.AddIdentitySeed(seed => seed.Role("First").WaitUpTo(TimeSpan.FromSeconds(5)));
+            s.AddIdentitySeed(seed => seed.Role("Second").WaitUpTo(TimeSpan.FromSeconds(11)));
+        });
+        plan.Build();
+
+        plan.WaitUpTo.Should().Be(TimeSpan.FromSeconds(11));
+    }
+
+    [Fact]
+    public void User_WithoutWithUserName_UsesTheEmailAsUserName()
+    {
+        var plan = PlanOf(s => s.AddIdentitySeed(seed => seed.User("audit@example.com", u => u.InRoles("Auditor"))));
+
+        var step = plan.Build().OfType<UserStep>().Single();
+        step.Email.Should().Be("audit@example.com");
+        step.UserName.Should().Be("audit@example.com");
+        step.Password.Should().BeNull();
+        step.Roles.Should().Equal("Auditor");
+    }
+
+    [Fact]
+    public void User_KeepsUserNamePasswordAndRolesInDeclarationOrder()
+    {
+        var plan = PlanOf(s => s.AddIdentitySeed(seed => seed.User("admin@localhost", u => u
+            .WithUserName("admin")
+            .WithPassword("Admin123!")
+            .InRoles("Administrator")
+            .InRoles("Accountant", "Administrator"))));
+
+        var step = plan.Build().OfType<UserStep>().Single();
+        step.UserName.Should().Be("admin");
+        step.Password.Should().Be("Admin123!");
+        step.Roles.Should().Equal(new[] { "Administrator", "Accountant" },
+            "InRoles accumulates in declaration order and de-duplicates");
+    }
+
+    [Fact]
+    public void AddIdentityInitializer_MapsOptionsOntoTheSeedAtBuildTime()
+    {
+        var plan = PlanOf(s => s.AddIdentityInitializer(o =>
+        {
+            o.AdminEmail = "root@x";
+            o.AdminUserName = "root";
+            o.AdminPassword = "Root123!";
+            o.AdminRoleName = "Owner";
+            o.ProjectionWaitTime = TimeSpan.FromSeconds(5);
+        }));
+
+        var steps = plan.Build();
+
+        steps.OfType<RoleStep>().Single().Name.Should().Be("Owner");
+        var user = steps.OfType<UserStep>().Single();
+        user.Email.Should().Be("root@x");
+        user.UserName.Should().Be("root");
+        user.Password.Should().Be("Root123!");
+        user.Roles.Should().Equal("Owner");
+        plan.WaitUpTo.Should().Be(TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public void AddIdentityInitializer_WithSeedAdminUserFalse_ContributesNothing()
+    {
+        var plan = PlanOf(s => s.AddIdentityInitializer(o => o.SeedAdminUser = false));
+
+        plan.Build().Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Backoff_Is_1_2_5_10_20_30_30_Seconds()
+    {
+        Enumerable.Range(1, 7)
+            .Select(IdentityInitializerService.Backoff)
+            .Should().Equal(
+                TimeSpan.FromSeconds(1),
+                TimeSpan.FromSeconds(2),
+                TimeSpan.FromSeconds(5),
+                TimeSpan.FromSeconds(10),
+                TimeSpan.FromSeconds(20),
+                TimeSpan.FromSeconds(30),
+                TimeSpan.FromSeconds(30));
+    }
+
+    [Fact]
+    public void WaitUpTo_RejectsANonPositiveBound()
+    {
+        var builder = new IdentitySeedBuilder();
+        builder.Invoking(b => b.WaitUpTo(TimeSpan.Zero)).Should().Throw<ArgumentOutOfRangeException>();
+    }
+}


### PR DESCRIPTION
## MicroPlumberd.Services.Identity — declarative identity seeding on readiness, never fatal (epic-083 / feature-001, PATCH)

Spec: `docs/epics/epic-083-micro-plumberd/features/feature-001-identity-initializer-readiness/` (requirements R1–R8, design.md, acceptance-tests.md AT-01…AT-08 + AT-02b/AT-06b).

### Defect (reproduced in erp, §6.77)
`IdentityInitializerService` slept `ProjectionWaitTime` then read the identity read models; when they had not caught up (or had not folded its own role append) it threw `Role 'X' does not exist` out of `ExecuteAsync` → .NET default `StopHost` took the host down with `/health` green. Also: the API could seed only one admin in one role — a public library that assumed a consumer's role vocabulary.

### What changes
- **`services.AddIdentitySeed(seed => seed.Role("A").User("e@x", u => u.WithPassword(..).InRoles("A")).Then(async (ctx, ct) => …).WaitUpTo(30s))`** — fluent, generic; no role/user name built into the library.
- **Runs on readiness**: `RolesModel`, `UsersModel`, `UserAuthorizationModel` implement `ICaughtUpHandler` and expose `Task Live`; the seed awaits them (bounded per attempt) instead of sleeping; every write is followed by a read-your-write visibility wait.
- **Never stops the host**: no exception escapes `ExecuteAsync`; Error log + bounded backoff (1/2/5/10/20/30 s); works with the .NET default `StopHost` left in place.
- **Idempotent/additive** ensures; retry-safe via runner-scoped written-keys memory (a write that succeeded but wasn't yet visible is not repeated); `EmailConfirmed` false→true is the only write ever applied to an existing declared user.
- **Observable**: `IdentitySeedState` + opt-in `AddHealthChecks().AddIdentitySeedHealthCheck()` (`identity`, untagged).
- **Compat**: `AddIdentityInitializer(o => …)` / `IdentityInitializerOptions` unchanged, now an adapter over the seed; `IdentityInitializerService` keeps name + public ctor, not sealed; `AddPlumberdIdentity` still returns `IServiceCollection`.
- README (now packed with this package): Seeding section, `HostOptions.BackgroundServiceExceptionBehavior` ruling, non-web hosts need `AddDataProtection()`, limitations (custom `ILookupNormalizer` unsupported in the stores; cross-host concurrent seeding).
- Example `Examples.Blazor.Identity2` uses the new API + explicit `HostOptions`.

### Tests (Docker in-memory KurrentDB, run sequentially)
- `IdentitySeedTests` 10/10 (AT-01…08, AT-02b, AT-06b — AT-06b mutation-verified: fails with the written-keys memory disabled)
- `IdentitySeedBuilderTests` 13/13 · `AdminSeedingTests` 2/2 (assertions unchanged; harness gained `AddDataProtection()` — was pre-existing red on master) · `CaughtUpTests` 5/5
- `MicroPlumberd.Tests.Unit`: 44/45 — the 1 failure (`ProcessManagerSourceGenerationTests.CommandTypes`) is pre-existing on master (control run on `5ac820d`).

Independent review: NOT-MERGEABLE → fixes → MERGEABLE-AFTER-MINORS → minors applied.

### Consumers after release (dependency check, run LAST)
- erp: bump, delete interim `ErpIdentitySeeder`, declare roles + first admin via `AddIdentitySeed`, keep `IdentityReadinessTests` and `HostOptions … Ignore`.
- website `RocketWelder.Web.Admin`: bump; add `Role("Finance")`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SaMD78KSgbXxJWsQ1K9BhQ
